### PR TITLE
Remove automatic PyPI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,13 +27,3 @@ after_success: coveralls
 
 notifications:
     email: never
-
-deploy:
-    provider: pypi
-    user: robinandeer
-    password:
-        secure: fQsE+5FUuXWuLMuGVirfSEz7WBc09gxDbEcPfIJFUQ2FzaGCQ+OGZpb6sbNCrazhqwnyyJ7b4ZD3bjJ++kWsmnpgvdUFZRDUUpcLuDtwzPSxHVx/1Zax4gMnny83Z1yF4O7m8bXt7HG1mPuKzPSHLOcTg3SxTQEgSi27dkeY4WE=
-    on:
-        tags: true
-        distributions: sdist bdist_wheel
-        repo: Clinical-Genomics/chanjo


### PR DESCRIPTION
When adding tags to repo, this triggers an automatic PyPI build through travis. This should be removed. 