### PR TITLE
Chanjo Dockerfile 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+.github
+.gitignore
+.travis.yml
+.gitlint.yaml
+docs
+tests
+Dockerfile
+Pipfile
+Pipfile.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - User can pass on file with row separated gene IDs for coverage calculation
+- Dockerfile
 
 ## [4.3.0] - 2020-02-05
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM frolvlad/alpine-miniconda3
+
+LABEL base_image="python:3.8-alpine3.12"
+LABEL about.home="https://github.com/Clinical-Genomics/chanjo"
+LABEL about.documentation="https://www.clinicalgenomics.se/chanjo/"
+LABEL about.tags="bam,NGS,coverage,sambamba,alpine,python3"
+LABEL about.license="MIT License (MIT)"
+
+# Install Sambamba using conda
+RUN conda update -n base -c defaults conda && conda install -c bioconda sambamba
+
+RUN conda install -c conda-forge ruamel.yaml
+
+# Install required libs
+RUN apk update \
+	&& apk --no-cache add bash python3
+
+WORKDIR /home/worker/app
+COPY . /home/worker/app
+
+# Install Chanjo requirements
+RUN pip install -r requirements.txt
+
+# Install the app
+RUN pip install -e .
+
+# Run commands as non-root user
+RUN adduser -D worker
+RUN chown worker:worker -R /home/worker
+USER worker

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM frolvlad/alpine-miniconda3
 
-LABEL base_image="python:3.8-alpine3.12"
+LABEL base_image="frolvlad/alpine-miniconda3"
 LABEL about.home="https://github.com/Clinical-Genomics/chanjo"
 LABEL about.documentation="https://www.clinicalgenomics.se/chanjo/"
-LABEL about.tags="bam,NGS,coverage,sambamba,alpine,python3"
+LABEL about.tags="chanjo,bam,NGS,coverage,sambamba,alpine,python,python3.7"
 LABEL about.license="MIT License (MIT)"
 
 # Install Sambamba using conda
@@ -28,3 +28,6 @@ RUN pip install -e .
 RUN adduser -D worker
 RUN chown worker:worker -R /home/worker
 USER worker
+
+ENTRYPOINT ["chanjo"]
+CMD ["--help"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ click
 path.py
 toolz
 ruamel.yaml
+importlib_metadata


### PR DESCRIPTION
fix #217 

### This PR adds | fixes:
- Adds a Dockerfile based on a Linux alpine distro that has already installed conda (so installing Sambamba is easier). It provides also the instructions to install and run Chanjo. 

**How to prepare for test**:
- [x] run `docker build -t chanjo:latest .`
- [x] run the container with : `docker run chanjo`

### Expected outcome:
- [x] You should see the help from the chanjo command line

### Review:
- [x] Code approved by MM
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
