### PR TITLE
Created docker-compose and Makefile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [] - 
+- docker-compose and Makefile
+
 ## [4.5.0] - 2020-11-12
 ### Added
 - Dockerfile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [] - 
+## [] -
+### Added
 - docker-compose and Makefile
 
 ## [4.5.0] - 2020-11-12

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,3 @@ RUN pip install -e .
 RUN adduser -D worker
 RUN chown worker:worker -R /home/worker
 USER worker
-
-ENTRYPOINT ["chanjo"]
-CMD ["--help"]

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 # @version 0.1
 
 .DEFAULT_GOAL := help
-.PHONY: build run init prune help up down bash-chanjo
+.PHONY: build run init prune help up down calculate
 
 build:    ## Build new images
 	docker-compose build

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,30 @@
+##
+# Chanjo
+#
+# @file
+# @version 0.1
+
+.DEFAULT_GOAL := help
+.PHONY: build run init prune help up down bash-chanjo
+
+build:    ## Build new images
+	docker-compose build
+init:    ## Initialize database and load demo data
+	echo "Setup chanjo database"
+	docker-compose run chanjo-cli /bin/bash -c "chanjo -d mysql+pymysql://chanjoUser:chanjoPassword@mariadb/chanjo4_test init --auto demodata && chanjo --config demodata/chanjo.yaml link demodata/hgnc.grch37p13.exons.bed"
+	echo "Loading coverage from demo files"
+	docker-compose run chanjo-cli chanjo -d mysql+pymysql://chanjoUser:chanjoPassword@mariadb/chanjo4_test load chanjo/init/demo-files/sample1.coverage.bed
+	docker-compose run chanjo-cli chanjo -d mysql+pymysql://chanjoUser:chanjoPassword@mariadb/chanjo4_test load chanjo/init/demo-files/sample2.coverage.bed
+	docker-compose run chanjo-cli chanjo -d mysql+pymysql://chanjoUser:chanjoPassword@mariadb/chanjo4_test load chanjo/init/demo-files/sample3.coverage.bed
+
+calculate: ## Simple command to calculate mean over data stored in database
+	echo "Calculate mean coverage"
+	docker-compose run chanjo-cli chanjo -d mysql+pymysql://chanjoUser:chanjoPassword@mariadb/chanjo4_test calculate mean
+
+prune: ## Remove orphans and dangling images
+	docker-compose down --remove-orphans
+	docker images prune
+help:    ## Show this help.
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+# end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,39 @@
+version: '3'
+# usage:
+# (sudo) docker-compose up -d
+# (sudo) docker-compose down
+services:
+    mariadb:
+      container_name: mariadb
+      image: mariadb:latest
+      restart: 'always'
+      environment:
+        - MYSQL_ROOT_PASSWORD=root
+        - MYSQL_DATABASE=chanjo4_test
+        - MYSQL_USER=chanjoUser
+        - MYSQL_PASSWORD=chanjoPassword
+      healthcheck: # Wait for the service to be ready before accepting incoming connections
+        test: "mysql --user=chanjoUser --password=chanjoPassword --execute \"SHOW DATABASES;\""
+        timeout: 10s
+        retries: 20
+      networks:
+        - chanjo-net
+
+    chanjo-cli:
+      container_name: chanjo-cli
+      build:
+        context: .
+        dockerfile: Dockerfile
+      depends_on:
+        mariadb:
+          condition: service_healthy # DB_URI=mysql+pymysql://chanjoUser:chanjoPassword@mariadb/chanjo4_test
+      networks:
+        - chanjo-net
+
+networks:
+  chanjo-net:
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+        - subnet: 172.21.0.0/24

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ path.py
 toolz
 ruamel.yaml
 importlib_metadata
+pymysql


### PR DESCRIPTION
### This PR adds | fixes:
- Added missing lib pymysql (fix #222)
- Created docker-composer file with chanjo-cli connected to mysql database
- Create Makefile for making it easy to setup database with data using containers
- Makefile has also an example command that uses container to calculate mean coverage for the demo samples

### How to test:
- [x] cd to root dir of this app
- [x] run `make`, it will explain the options you have
- [x] To set up a demo database (mysql using MariaDB docker Image) run `make init`
- [x] To calculate the mean coverage over the 3 demo samples run `make calculate`
- [x] run `make prune` to stop remove all created containers

### Expected outcome:
- [x] All commands above should work

### Review:
- [ ] Code approved by
- [ ] Tests executed by
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
