### PR TITLE
Fix report crash by freezing SQLAlchemy and doclinks fix

### DIFF
--- a/.github/workflows/pytest_n_coveralls.yml
+++ b/.github/workflows/pytest_n_coveralls.yml
@@ -21,6 +21,6 @@ jobs:
     - name: Run pytest and coveralls
       run: |
         pytest --cov=chanjo tests/
-        coveralls
+        coveralls --service=github
       env:
         GITHUB_TOKEN: ${{ github.token }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [4.6.1] - 2021-07-08
 ### Fixed
-- Freeze SQLAlchemy to a version <1.4 to avoid report creation crashing 
+- Freeze SQLAlchemy to a version <1.4 to avoid report creation crashing
+- Fix links to documentation pages
 
 ## [4.6] - 2020-11-20
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [4.6.1] - 2021-07-08
+### Fixed
+- Freeze SQLAlchemy to a version <1.4 to avoid report creation crashing 
+
 ## [4.6] - 2020-11-20
 ### Added
 - docker-compose and Makefile

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -28,7 +28,6 @@ Chanjo if following the [GitHub flow][gh-flow] branching model which means that 
 
 
 
-
 [pr-version]: docs/img/version.png
-[development-guide]: http://www.clinicalgenomics.se/development/publish/prod/
-[gh-flow]: http://www.clinicalgenomics.se/development/dev/models/#rolling-release-github-flow
+[development-guide]: http://clinical-genomics.github.io/development/publish/prod/
+[gh-flow]: http://clinical-genomics.github.io/development/dev/models/#rolling-release-github-flow

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM frolvlad/alpine-miniconda3
 
 LABEL base_image="frolvlad/alpine-miniconda3"
 LABEL about.home="https://github.com/Clinical-Genomics/chanjo"
-LABEL about.documentation="https://www.clinicalgenomics.se/chanjo/"
+LABEL about.documentation="https://clinical-genomics.github.io/chanjo/"
 LABEL about.tags="chanjo,bam,NGS,coverage,sambamba,alpine,python,python3.7"
 LABEL about.license="MIT License (MIT)"
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ to get started!
 
 
 [unix]: http://en.wikipedia.org/wiki/Unix_philosophy
-[docs]: http://www.clinicalgenomics.se/chanjo/
+[docs]: https://clinical-genomics.github.io/chanjo/
 [bedtools]: http://bedtools.readthedocs.org/en/latest/
 [thesis]: https://s3.amazonaws.com/tudo/chanjo/RobinAndeerMastersThesisFinal_2013.pdf
 [sambamba]: http://lomereiter.github.io/sambamba/

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 ---
 site_name: Chanjo Docs
-site_url: http://www.clinicalgenomics.se/chanjo/
+site_url: https://clinical-genomics.github.io/chanjo/
 repo_url: https://github.com/Clinical-Genomics/chanjo
 dev_addr: "0.0.0.0:4000"
 site_author: Clinical Genomics bioinfo team

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ toolz
 ruamel.yaml
 importlib_metadata
 pymysql
+sqlalchemy==1.3.*

--- a/setup.py
+++ b/setup.py
@@ -4,27 +4,27 @@
 # To use a consistent encoding
 import codecs
 import os
-# Always prefer setuptools over distutils
-from setuptools import setup, find_packages
-from setuptools.command.test import test as TestCommand
 import sys
 
+# Always prefer setuptools over distutils
+from setuptools import find_packages, setup
+from setuptools.command.test import test as TestCommand
+
 # Shortcut for building/publishing to Pypi
-if sys.argv[-1] == 'publish':
-    os.system('python setup.py sdist bdist_wheel upload')
+if sys.argv[-1] == "publish":
+    os.system("python setup.py sdist bdist_wheel upload")
     sys.exit()
 
 
-def parse_reqs(req_path='./requirements.txt'):
+def parse_reqs(req_path="./requirements.txt"):
     """Recursively parse requirements from nested pip files."""
     install_requires = []
-    with codecs.open(req_path, 'r') as handle:
+    with codecs.open(req_path, "r") as handle:
         # remove comments and empty lines
-        lines = (line.strip() for line in handle
-                 if line.strip() and not line.startswith('#'))
+        lines = (line.strip() for line in handle if line.strip() and not line.startswith("#"))
         for line in lines:
             # check for nested requirements files
-            if line.startswith('-r'):
+            if line.startswith("-r"):
                 # recursively call this function
                 install_requires += parse_reqs(req_path=line[3:])
             else:
@@ -49,78 +49,68 @@ class PyTest(TestCommand):
         """Execute the test runner command."""
         # Import here, because outside the required eggs aren't loaded yet
         import pytest
+
         sys.exit(pytest.main(self.test_args))
 
 
 setup(
-    name='chanjo',
-
+    name="chanjo",
     # Versions should comply with PEP440. For a discussion on
     # single-sourcing the version across setup.py and the project code,
     # see http://packaging.python.org/en/latest/tutorial.html#version
-    version='4.6.0',
-
-    description='Coverage analysis tool for clinical sequencing',
+    version="4.6.1",
+    description="Coverage analysis tool for clinical sequencing",
     # What does your project relate to? Separate with spaces.
-    keywords='coverage sequencing clinical exome completeness diagnostics',
-    author='Robin Andeer',
-    author_email='robin.andeer@gmail.com',
-    license='MIT',
-
+    keywords="coverage sequencing clinical exome completeness diagnostics",
+    author="Robin Andeer",
+    author_email="robin.andeer@gmail.com",
+    license="MIT",
     # The project's main homepage
-    url='http://www.chanjo.co/',
-
-    packages=find_packages(exclude=('tests*', 'docs', 'examples')),
-
+    url="http://www.chanjo.co/",
+    packages=find_packages(exclude=("tests*", "docs", "examples")),
     # If there are data files included in your packages that need to be
     # installed, specify them here.
     include_package_data=True,
-    package_data=dict(chanjo=['demo/files/*']),
+    package_data=dict(chanjo=["demo/files/*"]),
     zip_safe=False,
-
     # Install requirements loaded from ``requirements.txt``
     install_requires=parse_reqs(),
     tests_require=[
-        'pytest',
+        "pytest",
     ],
     cmdclass=dict(test=PyTest),
-
     # To provide executable scripts, use entry points in preference to the
     # "scripts" keyword. Entry points provide cross-platform support and
     # allow pip to create the appropriate form of executable for the
     # target platform.
     entry_points={
-        'console_scripts': [
-            'chanjo = chanjo.cli:root',
+        "console_scripts": [
+            "chanjo = chanjo.cli:root",
         ],
-        'chanjo.subcommands.4': [
-            'init = chanjo.cli:init',
-            'sex = chanjo.cli:sex',
-            'sambamba = chanjo.cli:sambamba',
-            'db = chanjo.cli:db_cmd',
-            'load = chanjo.cli:load',
-            'link = chanjo.cli:link',
-            'calculate = chanjo.cli:calculate',
-        ]
+        "chanjo.subcommands.4": [
+            "init = chanjo.cli:init",
+            "sex = chanjo.cli:sex",
+            "sambamba = chanjo.cli:sambamba",
+            "db = chanjo.cli:db_cmd",
+            "load = chanjo.cli:load",
+            "link = chanjo.cli:link",
+            "calculate = chanjo.cli:calculate",
+        ],
     },
-
     # See: http://pypi.python.org/pypi?%3Aaction=list_classifiers
     classifiers=[
         # How mature is this project? Common values are:
         #   3 - Alpha
         #   4 - Beta
         #   5 - Production/Stable
-        'Development Status :: 5 - Production/Stable',
-
+        "Development Status :: 5 - Production/Stable",
         # Indicate who your project is intended for
-        'Intended Audience :: Science/Research',
-        'Topic :: Software Development',
-        'Topic :: Scientific/Engineering :: Bio-Informatics',
-
+        "Intended Audience :: Science/Research",
+        "Topic :: Software Development",
+        "Topic :: Scientific/Engineering :: Bio-Informatics",
         # Pick your license as you wish (should match "license" above)
-        'License :: OSI Approved :: MIT License',
-
-        'Programming Language :: Python :: 3',
-        'Environment :: Console',
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python :: 3",
+        "Environment :: Console",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
     # Versions should comply with PEP440. For a discussion on
     # single-sourcing the version across setup.py and the project code,
     # see http://packaging.python.org/en/latest/tutorial.html#version
-    version="4.6.1",
+    version="4.6.0",
     description="Coverage analysis tool for clinical sequencing",
     # What does your project relate to? Separate with spaces.
     keywords="coverage sequencing clinical exome completeness diagnostics",

--- a/setup.py
+++ b/setup.py
@@ -4,27 +4,27 @@
 # To use a consistent encoding
 import codecs
 import os
+# Always prefer setuptools over distutils
+from setuptools import setup, find_packages
+from setuptools.command.test import test as TestCommand
 import sys
 
-# Always prefer setuptools over distutils
-from setuptools import find_packages, setup
-from setuptools.command.test import test as TestCommand
-
 # Shortcut for building/publishing to Pypi
-if sys.argv[-1] == "publish":
-    os.system("python setup.py sdist bdist_wheel upload")
+if sys.argv[-1] == 'publish':
+    os.system('python setup.py sdist bdist_wheel upload')
     sys.exit()
 
 
-def parse_reqs(req_path="./requirements.txt"):
+def parse_reqs(req_path='./requirements.txt'):
     """Recursively parse requirements from nested pip files."""
     install_requires = []
-    with codecs.open(req_path, "r") as handle:
+    with codecs.open(req_path, 'r') as handle:
         # remove comments and empty lines
-        lines = (line.strip() for line in handle if line.strip() and not line.startswith("#"))
+        lines = (line.strip() for line in handle
+                 if line.strip() and not line.startswith('#'))
         for line in lines:
             # check for nested requirements files
-            if line.startswith("-r"):
+            if line.startswith('-r'):
                 # recursively call this function
                 install_requires += parse_reqs(req_path=line[3:])
             else:
@@ -49,68 +49,78 @@ class PyTest(TestCommand):
         """Execute the test runner command."""
         # Import here, because outside the required eggs aren't loaded yet
         import pytest
-
         sys.exit(pytest.main(self.test_args))
 
 
 setup(
-    name="chanjo",
+    name='chanjo',
+
     # Versions should comply with PEP440. For a discussion on
     # single-sourcing the version across setup.py and the project code,
     # see http://packaging.python.org/en/latest/tutorial.html#version
-    version="4.6.0",
-    description="Coverage analysis tool for clinical sequencing",
+    version='4.6.0',
+
+    description='Coverage analysis tool for clinical sequencing',
     # What does your project relate to? Separate with spaces.
-    keywords="coverage sequencing clinical exome completeness diagnostics",
-    author="Robin Andeer",
-    author_email="robin.andeer@gmail.com",
-    license="MIT",
+    keywords='coverage sequencing clinical exome completeness diagnostics',
+    author='Robin Andeer',
+    author_email='robin.andeer@gmail.com',
+    license='MIT',
+
     # The project's main homepage
-    url="http://www.chanjo.co/",
-    packages=find_packages(exclude=("tests*", "docs", "examples")),
+    url='http://www.chanjo.co/',
+
+    packages=find_packages(exclude=('tests*', 'docs', 'examples')),
+
     # If there are data files included in your packages that need to be
     # installed, specify them here.
     include_package_data=True,
-    package_data=dict(chanjo=["demo/files/*"]),
+    package_data=dict(chanjo=['demo/files/*']),
     zip_safe=False,
+
     # Install requirements loaded from ``requirements.txt``
     install_requires=parse_reqs(),
     tests_require=[
-        "pytest",
+        'pytest',
     ],
     cmdclass=dict(test=PyTest),
+
     # To provide executable scripts, use entry points in preference to the
     # "scripts" keyword. Entry points provide cross-platform support and
     # allow pip to create the appropriate form of executable for the
     # target platform.
     entry_points={
-        "console_scripts": [
-            "chanjo = chanjo.cli:root",
+        'console_scripts': [
+            'chanjo = chanjo.cli:root',
         ],
-        "chanjo.subcommands.4": [
-            "init = chanjo.cli:init",
-            "sex = chanjo.cli:sex",
-            "sambamba = chanjo.cli:sambamba",
-            "db = chanjo.cli:db_cmd",
-            "load = chanjo.cli:load",
-            "link = chanjo.cli:link",
-            "calculate = chanjo.cli:calculate",
-        ],
+        'chanjo.subcommands.4': [
+            'init = chanjo.cli:init',
+            'sex = chanjo.cli:sex',
+            'sambamba = chanjo.cli:sambamba',
+            'db = chanjo.cli:db_cmd',
+            'load = chanjo.cli:load',
+            'link = chanjo.cli:link',
+            'calculate = chanjo.cli:calculate',
+        ]
     },
+
     # See: http://pypi.python.org/pypi?%3Aaction=list_classifiers
     classifiers=[
         # How mature is this project? Common values are:
         #   3 - Alpha
         #   4 - Beta
         #   5 - Production/Stable
-        "Development Status :: 5 - Production/Stable",
+        'Development Status :: 5 - Production/Stable',
+
         # Indicate who your project is intended for
-        "Intended Audience :: Science/Research",
-        "Topic :: Software Development",
-        "Topic :: Scientific/Engineering :: Bio-Informatics",
+        'Intended Audience :: Science/Research',
+        'Topic :: Software Development',
+        'Topic :: Scientific/Engineering :: Bio-Informatics',
+
         # Pick your license as you wish (should match "license" above)
-        "License :: OSI Approved :: MIT License",
-        "Programming Language :: Python :: 3",
-        "Environment :: Console",
+        'License :: OSI Approved :: MIT License',
+
+        'Programming Language :: Python :: 3',
+        'Environment :: Console',
     ],
 )


### PR DESCRIPTION
### This PR adds | fixes:
- Fix #232 (Error creating chanjo report)
- Fix #231 (Wrong link to the documentation)

### **How to prepare for test**:
- Follow the instructions from the issue: https://github.com/Clinical-Genomics/chanjo/issues/232#issue-939479078 and make sure that you can reproduce the error using chanjo master branch.

### How to test:
- Switch to this branch and install again chanjo (pip install -e .)
- Repeat the procedure described in the issue and notice that the html report is now working

### Expected outcome:
- [x] That it works!

### Review:
- [ ] Code approved by
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
