### PR TITLE
PyPI publish && mkdocs deploy actions

### DIFF
--- a/.github/workflows/deploy_mkdocs.yml
+++ b/.github/workflows/deploy_mkdocs.yml
@@ -1,0 +1,19 @@
+name: Deploy mkdocs on new release action
+
+on: [pull_request]
+
+jobs:
+ deploy-docs:
+   name: Deploy Docs to GitHubIO
+   runs-on: ubuntu-latest
+   steps:
+    - name: Checkout repo
+      uses: actions/checkout@v2
+    - name: Setup environment for docs deployment
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.x
+    - name: Install mkdocs
+      run: pip install mkdocs mkdocs-material markdown-include
+    - name: Deploy documentation
+      run: mkdocs gh-deploy --force

--- a/.github/workflows/deploy_mkdocs.yml
+++ b/.github/workflows/deploy_mkdocs.yml
@@ -1,6 +1,9 @@
 name: Deploy mkdocs on new release action
 
-on: [pull_request]
+on:
+ release:
+  types:
+   - created
 
 jobs:
  deploy-docs:

--- a/.github/workflows/pypi_build_n_publish.yml
+++ b/.github/workflows/pypi_build_n_publish.yml
@@ -1,6 +1,9 @@
 name: Publish to PyPI && publish mkdocs action
 
-on: [pull_request]
+on:
+ release:
+  types:
+   - created
 
 jobs:
  build-n-publish:

--- a/.github/workflows/pypi_build_n_publish.yml
+++ b/.github/workflows/pypi_build_n_publish.yml
@@ -1,0 +1,53 @@
+name: Publish to PyPI && publish mkdocs action
+
+on: [pull_request]
+
+jobs:
+ build-n-publish:
+  name: Build and publish Python distribution to PyPI
+  runs-on: ubuntu-18.04
+  steps:
+   - name: Check out git repository
+     uses: actions/checkout@v2
+
+   - name: Set up Python 3.7
+     uses: actions/setup-python@v2
+     with:
+      python-version: 3.7
+
+   - name: Install build tools
+     run: >-
+        python -m
+        pip install
+        wheel
+        twine
+        --user
+
+   - name: Build a binary wheel and a source tarball
+     run: >-
+        python
+        setup.py
+        sdist
+        bdist_wheel
+
+   - name: Publish distribution 📦 to PyPI
+     uses: pypa/gh-action-pypi-publish@master
+     with:
+       user: __token__
+       password: ${{ secrets.pypi_password }}
+
+
+ deploy-docs:
+   name: Deploy Docs to GitHubIO
+   runs-on: ubuntu-latest
+   steps:
+    - name: Checkout repo
+      uses: actions/checkout@v2
+    - name: Setup environment for docs deployment
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.x
+    - name: Install mkdocs
+      run: pip install mkdocs mkdocs-material markdown-include
+    - name: Deploy documentation
+      run: mkdocs gh-deploy --force

--- a/.github/workflows/pypi_build_n_publish.yml
+++ b/.github/workflows/pypi_build_n_publish.yml
@@ -35,19 +35,3 @@ jobs:
      with:
        user: __token__
        password: ${{ secrets.pypi_password }}
-
-
- deploy-docs:
-   name: Deploy Docs to GitHubIO
-   runs-on: ubuntu-latest
-   steps:
-    - name: Checkout repo
-      uses: actions/checkout@v2
-    - name: Setup environment for docs deployment
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.x
-    - name: Install mkdocs
-      run: pip install mkdocs mkdocs-material markdown-include
-    - name: Deploy documentation
-      run: mkdocs gh-deploy --force

--- a/.github/workflows/pypi_build_n_publish.yml
+++ b/.github/workflows/pypi_build_n_publish.yml
@@ -1,9 +1,6 @@
 name: Publish to PyPI && publish mkdocs action
 
-on:
- release:
-  types:
-   - created
+on: [pull_request]
 
 jobs:
  build-n-publish:
@@ -37,4 +34,4 @@ jobs:
      uses: pypa/gh-action-pypi-publish@master
      with:
        user: __token__
-       password: ${{ secrets.pypi_password }}
+       password: ${{ secrets.PYPI_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [x.x.x] -
+### Added
+- github action to publish the repo to PyPI and publish mkdocs on new release event
+
+
 ## [4.6.1] - 2021-07-08
 ### Fixed
 - Freeze SQLAlchemy to a version <1.4 to avoid report creation crashing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [x.x.x] -
 ### Added
-- github action to publish the repo to PyPI and publish mkdocs on new release event
-
+- github actions to publish the repo to PyPI and publish mkdocs on new release event
 
 ## [4.6.1] - 2021-07-08
 ### Fixed


### PR DESCRIPTION
### This PR adds | fixes:
- github action to publish the repo to PyPI when a new version is created (triggering it now with this PR, and changing the action later) (fix #234)
- mkdocs deploy when a new version is created (triggering it now with this PR, and changing the action later)

### How to test:
- It's github actions. The mkdocs publishing works:
![image](https://user-images.githubusercontent.com/28093618/124892604-4c3f1800-dfda-11eb-8150-54c2bd0c0a6b.png)

- For the PyPI publishing I need someone with access to the PyPI repo to create a token!

### Expected outcome:
- [ ] Both actions should be triggered when a new release is created

### Review:
- [ ] Code approved by
- [ ] Tests executed by
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
