### PR TITLE
Fix sambamba test issue

### DIFF
--- a/.github/workflows/pytest_n_coveralls.yml
+++ b/.github/workflows/pytest_n_coveralls.yml
@@ -9,6 +9,7 @@ jobs:
       uses: actions/setup-python@master
       with:
         python-version: 3.7
+    - run: echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> $GITHUB_PATH
     - name: Install Sambamba
       run: |
         brew install brewsci/bio/sambamba

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [x.x.x] -
 ### Added
 - github actions to publish the repo to PyPI and publish mkdocs on new release event
+### Fixed
+- Add missing brew path to GitHub action. It has been removed from PATH variable in Ubuntu
 
 ## [4.6.1] - 2021-07-08
 ### Fixed


### PR DESCRIPTION
### This PR adds | fixes:
- Attempt at fixing the error caused by brew command not found in a GitHub action. 

I believe the problem might have been caused by this breaking change in Ubuntu: https://github.com/actions/runner-images/issues/6283


### How to test:
- GitHub actions tests should be successful

### Review:
- [ ] Code approved by
- [ ] Tests executed by GitHub actions

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
