### PR TITLE
Extend Docker setup in README

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,8 @@ services:
         test: "mysql --user=chanjoUser --password=chanjoPassword --execute \"SHOW DATABASES;\""
         timeout: 10s
         retries: 20
+      volumes:
+        - mysqldata:/home/worker/data/database
       networks:
         - chanjo-net
 
@@ -29,6 +31,9 @@ services:
           condition: service_healthy # DB_URI=mysql+pymysql://chanjoUser:chanjoPassword@mariadb/chanjo4_test
       networks:
         - chanjo-net
+
+volumes:
+  mysqldata:
 
 networks:
   chanjo-net:


### PR DESCRIPTION
### This PR adds | fixes:
- Fix #240
- Extends README Docker info already provided by PR #242 242

**How to prepare for test**:
- [ ] `ssh` to ...
- [ ] Install on stage:
`bash servers/resources/SERVER.scilifelab.se/update-[THIS_TOOL]-stage.sh [THIS-BRANCH-NAME]`

### How to test:
- Test commands locally

### Expected outcome:
- [ ] Sample should be loaded using the Docker-compose command

### Review:
- [ ] Code approved by
- [ ] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
