### PR TITLE
Replace ruamel.yaml with pyyaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [x.x.x] -
 ### Added
 - github actions to publish the repo to PyPI and publish mkdocs on new release event
+### Changed
+- Replace ruamel.yaml with pyyaml lib
 ### Fixed
 - Add missing brew path to GitHub action. It has been removed from PATH variable in Ubuntu
 - Badges on README page

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,6 @@ LABEL about.license="MIT License (MIT)"
 # Install Sambamba using conda
 RUN conda update -n base -c defaults conda && conda install -c bioconda sambamba
 
-RUN conda install -c conda-forge ruamel.yaml
-
 # Install required libs
 RUN apk update \
 	&& apk --no-cache add bash python3

--- a/chanjo/cli/base.py
+++ b/chanjo/cli/base.py
@@ -10,7 +10,7 @@ import pkg_resources
 
 import click
 import coloredlogs
-import ruamel.yaml
+import yaml
 
 from chanjo import __version__, __title__
 
@@ -56,7 +56,7 @@ def root(context, config, database, log_level, log_file):
     # avoid setting global defaults in Click options, do it below when
     if os.path.exists(config):
         with open(config) as conf_handle:
-            context.obj = ruamel.yaml.safe_load(conf_handle)
+            context.obj = yaml.safe_load(conf_handle)
     else:
         context.obj = {}
     context.obj['database'] = (database or context.obj.get('database'))

--- a/chanjo/cli/init.py
+++ b/chanjo/cli/init.py
@@ -5,7 +5,7 @@ import logging
 
 import click
 from path import Path
-import ruamel.yaml
+import yaml
 
 from chanjo.store.api import ChanjoDB
 from chanjo.init.bootstrap import pull, BED_NAME, DB_NAME
@@ -55,11 +55,10 @@ def init(context, force, demo, auto, root_dir):
     # setup config file
     root_path.makedirs_p()
     conf_path = root_path.joinpath('chanjo.yaml')
-    with codecs.open(conf_path, 'w', encoding='utf-8') as conf_handle:
+    with open(conf_path, 'w') as conf_handle:
         data = {'database': db_uri}
-        data_str = ruamel.yaml.dump(data, Dumper=ruamel.yaml.RoundTripDumper)
         LOG.info("writing config file: %s", conf_path)
-        conf_handle.write(data_str)
+        yaml.dump(data, conf_handle, default_flow_style=False)
 
     if is_bootstrapped:
         click.echo('Chanjo bootstrap successful! Now run: ')

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ alchy
 click
 path.py
 toolz
-ruamel.yaml
+pyyaml
 importlib_metadata
 pymysql
 sqlalchemy==1.3.*

--- a/tests/cli/test_cli_base.py
+++ b/tests/cli/test_cli_base.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import os
 
-import ruamel.yaml
+import yaml
 
 
 def test_logging_to_file(tmpdir, invoke_cli):
@@ -34,7 +34,7 @@ def test_with_config(tmpdir, invoke_cli):
     db_path = str(tmpdir.join('coverage.sqlite3'))
     data = {'database': db_path}
     with open(conf_path, 'w') as handle:
-        handle.write(ruamel.yaml.dump(data, Dumper=ruamel.yaml.RoundTripDumper))
+        yaml.dump(data, handle, default_flow_style=False)
     # WHEN launching CLI with config
     result = invoke_cli(['-c', conf_path, 'db', 'setup'])
     # THEN config values should be picked up

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -42,5 +42,5 @@ def test_init_no_bootstrap(tmpdir, invoke_cli):
     assert result.exit_code == 0
     conf_path = tmpdir.join('chanjo.yaml')
     with open(str(conf_path), 'r') as handle:
-        yaml.dump(data, handle, default_flow_style=False)
+        data = yaml.safe_load(handle)
     assert 'coverage.sqlite3' in data['database']

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -2,7 +2,7 @@
 from tempfile import gettempdir
 
 from mock import patch
-import ruamel.yaml
+import yaml
 
 from chanjo.testutils import FakeZipFile, fake_urlretrieve
 
@@ -42,5 +42,5 @@ def test_init_no_bootstrap(tmpdir, invoke_cli):
     assert result.exit_code == 0
     conf_path = tmpdir.join('chanjo.yaml')
     with open(str(conf_path), 'r') as handle:
-        data = ruamel.yaml.safe_load(handle)
+        yaml.dump(data, handle, default_flow_style=False)
     assert 'coverage.sqlite3' in data['database']


### PR DESCRIPTION
### This PR adds | fixes:
- Avoid lib error 

```
FAILED tests/cli/test_cli_base.py::test_with_config - AttributeError: 
"dump()" has been removed, use

  yaml = YAML(typ='unsafe', pure=True)
  yaml.dump(...)

instead of file "/home/runner/work/chanjo/chanjo/tests/cli/test_cli_base.py", line 37
```

### How to test:
- Automatic tests

### Expected outcome:
- [x] All tests should pass

### Review:
- [x] Code approved by DN
- [x] Tests executed by GitHub actions

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
