### PR TITLE
Update actions: python version, CHANGELOG reminder, lint and format

### DIFF
--- a/.github/workflows/deploy_mkdocs.yml
+++ b/.github/workflows/deploy_mkdocs.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Setup environment for docs deployment
       uses: actions/setup-python@v5
       with:
-        python-version: 3.x
+        python-version: 3.11
     - name: Install mkdocs
       run: pip install mkdocs mkdocs-material markdown-include
     - name: Deploy documentation

--- a/.github/workflows/keep_a_changelog.yml
+++ b/.github/workflows/keep_a_changelog.yml
@@ -1,0 +1,15 @@
+name: "Changelog Reminder"
+on:
+  pull_request:
+      types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+
+jobs:
+  # Enforces the update of a changelog file on every pull request
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: dangoslen/changelog-enforcer@v3
+      with:
+        changeLogPath: 'CHANGELOG.md'
+        skipLabels: 'Skip-Changelog'

--- a/.github/workflows/linting_only.yml
+++ b/.github/workflows/linting_only.yml
@@ -1,0 +1,47 @@
+name: Lint files - no fixing
+
+# This will check linting in local PRs
+on: ["push", "pull_request"]
+
+jobs:
+  build:
+
+    name: Lint-only
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.11]
+
+    steps:
+
+    # Check out Scout code
+    - name: Check out git repository
+      uses: actions/checkout@v4
+
+    # Set up python
+    - name: Set up Python ${{ matrix.python-version}}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version}}
+
+    - name: Install Python Dependencies
+      run: |
+        pip install black flake8 isort
+
+    - name: Run linters
+      uses: wearerequired/lint-action@v2
+      # Let linters fix problems if they can
+      with:
+        github_token: ${{ secrets.github_token }}
+        auto_fix: false
+        # Enable linters
+        black: true
+        black_args: "--check -l 100"
+        # stop the build if there are Python syntax errors or undefined names
+        flake8: true
+        flake8_args: "chanjo/ --count --select=E9,F63,F7,F82 --show-source --statistics"
+
+    - name: Run isort
+      uses: jamescurtin/isort-action@master
+      with:
+          configuration: "--check-only --diff -m 3 --tc --fgw 0 --up -n -l 100"

--- a/.github/workflows/pypi_build_n_publish.yml
+++ b/.github/workflows/pypi_build_n_publish.yml
@@ -13,10 +13,10 @@ jobs:
    - name: Check out git repository
      uses: actions/checkout@v4
 
-   - name: Set up Python 3.8
+   - name: Set up Python 3.11
      uses: actions/setup-python@v5
      with:
-      python-version: 3.8
+      python-version: 3.11
 
    - name: Install build tools
      run: >-

--- a/.github/workflows/pytest_n_coveralls.yml
+++ b/.github/workflows/pytest_n_coveralls.yml
@@ -8,7 +8,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: 3.8
+        python-version: 3.11
     - run: echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> $GITHUB_PATH
     - name: Install Sambamba
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [4.7.1] - 2024-06-05
 ### Fixed
 - Added `cryptography` module among the dependencies
+- Refactored to allow later python versions than 3.8 (pkg_resources to importlib, os.path and path.py to pathlib, distutils to shutil) [#262](https://github.com/Clinical-Genomics/chanjo/pull/262)
+- Updated actions to use python 3.11, add changelog reminder, add linting, format for linters
 
 ## [4.7] - 2024-05-22
 ### Added

--- a/chanjo/__init__.py
+++ b/chanjo/__init__.py
@@ -8,6 +8,7 @@ Coverage analysis for clinical sequencing.
 :licence: MIT, see LICENCE for more details
 """
 import logging
+
 try:
     from importlib.metadata import version
 except ImportError:  # Backport support for importlib metadata on Python 3.7
@@ -23,18 +24,18 @@ __banner__ = r"""
                             /___/
 """
 
-__title__ = 'chanjo'
-__summary__ = 'coverage analysis tool for clinical sequencing'
-__uri__ = 'http://www.chanjo.co/'
+__title__ = "chanjo"
+__summary__ = "coverage analysis tool for clinical sequencing"
+__uri__ = "http://www.chanjo.co/"
 
 __version__ = version(__title__)
-__codename__ = 'Optimistic Otter'
+__codename__ = "Optimistic Otter"
 
-__author__ = 'Robin Andeer'
-__email__ = 'robin.andeer@gmail.com'
+__author__ = "Robin Andeer"
+__email__ = "robin.andeer@gmail.com"
 
-__license__ = 'MIT'
-__copyright__ = 'Copyright 2016 Robin Andeer'
+__license__ = "MIT"
+__copyright__ = "Copyright 2016 Robin Andeer"
 
 # the user should dictate what happens when a logging event occurs
 logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/chanjo/calculate.py
+++ b/chanjo/calculate.py
@@ -6,7 +6,6 @@ from chanjo.store.models import Transcript, TranscriptStat
 
 
 class CalculateMixin:
-
     """Methods for calculating various metrics."""
 
     def mean(self, sample_ids=None):
@@ -39,16 +38,21 @@ class CalculateMixin:
     def sample_coverage(self, sample_ids: list, genes: list) -> dict:
         """Calculate coverage for samples."""
         with self.begin() as session:
-            query = session.query(
-                TranscriptStat.sample_id.label('sample_id'),
-                func.avg(TranscriptStat.mean_coverage).label('mean_coverage'),
-                func.avg(TranscriptStat.completeness_10).label('mean_completeness'),
-            ).join(
-                Transcript,
-            ).filter(
-                Transcript.gene_id.in_(genes),
-                TranscriptStat.sample_id.in_(sample_ids),
-            ).group_by(TranscriptStat.sample_id)
+            query = (
+                session.query(
+                    TranscriptStat.sample_id.label("sample_id"),
+                    func.avg(TranscriptStat.mean_coverage).label("mean_coverage"),
+                    func.avg(TranscriptStat.completeness_10).label("mean_completeness"),
+                )
+                .join(
+                    Transcript,
+                )
+                .filter(
+                    Transcript.gene_id.in_(genes),
+                    TranscriptStat.sample_id.in_(sample_ids),
+                )
+                .group_by(TranscriptStat.sample_id)
+            )
 
             data = {
                 result.sample_id: {

--- a/chanjo/cli/__init__.py
+++ b/chanjo/cli/__init__.py
@@ -1,7 +1,7 @@
 from .base import root
 from .calculate import calculate
-from .sex import sex
-from .load import link, load
-from .sambamba import sambamba
 from .db import db_cmd
 from .init import init
+from .load import link, load
+from .sambamba import sambamba
+from .sex import sex

--- a/chanjo/cli/base.py
+++ b/chanjo/cli/base.py
@@ -6,6 +6,7 @@ Command line interface (console entry points). Based on Click_.
 """
 import logging
 import os
+
 try:
     from importlib.metadata import entry_points
 except ImportError:  # Backport support for importlib metadata on Python 3.7
@@ -15,11 +16,12 @@ import click
 import coloredlogs
 import yaml
 
-from chanjo import __version__, __title__
+from chanjo import __title__, __version__
 
 LOG = logging.getLogger(__name__)
 
-COMMAND_GROUP_KEY = 'chanjo.subcommands.4'
+COMMAND_GROUP_KEY = "chanjo.subcommands.4"
+
 
 class EntryPointsCLI(click.MultiCommand):
     """Add sub-commands dynamically to a CLI via entry points."""
@@ -27,7 +29,7 @@ class EntryPointsCLI(click.MultiCommand):
     def _iter_commands(self):
         """Iterate over all sub-commands as defined by the entry point."""
         # Get all entry points for the specified group
-        if hasattr(entry_points(), 'select'):
+        if hasattr(entry_points(), "select"):
             # Python >3.10, importlib
             eps = entry_points(group=COMMAND_GROUP_KEY)
         else:
@@ -49,16 +51,17 @@ class EntryPointsCLI(click.MultiCommand):
 
 
 @click.group(cls=EntryPointsCLI)
-@click.option('-c', '--config', default='./chanjo.yaml',
-              type=click.Path(), help='path to config file')
-@click.option('-d', '--database', help='path/URI of the SQL database')
-@click.option('-l', '--log-level', default='INFO')
-@click.option('--log-file', type=click.File('a'))
+@click.option(
+    "-c", "--config", default="./chanjo.yaml", type=click.Path(), help="path to config file"
+)
+@click.option("-d", "--database", help="path/URI of the SQL database")
+@click.option("-l", "--log-level", default="INFO")
+@click.option("--log-file", type=click.File("a"))
 @click.version_option(__version__, prog_name=__title__)
 @click.pass_context
 def root(context, config, database, log_level, log_file):
     """Clinical sequencing coverage analysis tool."""
-    logout = log_file or click.get_text_stream('stderr')
+    logout = log_file or click.get_text_stream("stderr")
     coloredlogs.install(level=log_level, stream=logout)
     LOG.debug("version %s", __version__)
 
@@ -68,7 +71,7 @@ def root(context, config, database, log_level, log_file):
             context.obj = yaml.safe_load(conf_handle)
     else:
         context.obj = {}
-    context.obj['database'] = (database or context.obj.get('database'))
+    context.obj["database"] = database or context.obj.get("database")
 
     # Update the context with new defaults from the config file
     context.default_map = context.obj

--- a/chanjo/cli/calculate.py
+++ b/chanjo/cli/calculate.py
@@ -1,11 +1,12 @@
 """Functions for calculating operations on database"""
+
 import json
 import logging
 
 import click
 
 from chanjo.store.api import ChanjoDB
-from chanjo.store.constants import STAT_COLUMNS, OMIM_GENE_IDS
+from chanjo.store.constants import OMIM_GENE_IDS, STAT_COLUMNS
 
 LOG = logging.getLogger(__name__)
 
@@ -23,30 +24,30 @@ def dump_json(data, pretty=False):
 @click.pass_context
 def calculate(context):
     """Calculate statistics across samples."""
-    context.obj['db'] = ChanjoDB(uri=context.obj['database'])
+    context.obj["db"] = ChanjoDB(uri=context.obj["database"])
 
 
 @calculate.command()
-@click.option('-p', '--pretty', is_flag=True)
-@click.option('-s', '--sample', multiple=True, help='sample to limit query to')
+@click.option("-p", "--pretty", is_flag=True)
+@click.option("-s", "--sample", multiple=True, help="sample to limit query to")
 @click.pass_context
 def mean(context, sample, pretty):
     """Calculate mean statistics."""
-    query = context.obj['db'].mean(sample_ids=sample)
-    columns = ['sample_id'] + STAT_COLUMNS
+    query = context.obj["db"].mean(sample_ids=sample)
+    columns = ["sample_id"] + STAT_COLUMNS
     for result in query:
         row = {column: value for column, value in zip(columns, result)}
         click.echo(dump_json(row, pretty=pretty))
 
 
 @calculate.command()
-@click.option('-p', '--pretty', is_flag=True, help="Print in pretty format")
-@click.option('-s', '--sample', multiple=True, type=str, help="Sample to get coverage for")
-@click.option('-o', '--omim', is_flag=True, help="Use genes in the OMIM panel")
-@click.option('-f', '--gene-file',
-              type=click.Path(exists=True),
-              help="File with row separated gene IDs")
-@click.argument('genes', nargs=-1)
+@click.option("-p", "--pretty", is_flag=True, help="Print in pretty format")
+@click.option("-s", "--sample", multiple=True, type=str, help="Sample to get coverage for")
+@click.option("-o", "--omim", is_flag=True, help="Use genes in the OMIM panel")
+@click.option(
+    "-f", "--gene-file", type=click.Path(exists=True), help="File with row separated gene IDs"
+)
+@click.argument("genes", nargs=-1)
 @click.pass_context
 def coverage(context, pretty, sample, omim, gene_file, genes):
     """Calculate coverage for sample on specified genes"""
@@ -55,5 +56,5 @@ def coverage(context, pretty, sample, omim, gene_file, genes):
     if gene_file:
         with open(gene_file) as file_handle:
             genes = file_handle.read().strip().split("\n")
-    query = context.obj['db'].sample_coverage(sample_ids=sample, genes=list(genes))
+    query = context.obj["db"].sample_coverage(sample_ids=sample, genes=list(genes))
     click.echo(dump_json(query, pretty=pretty))

--- a/chanjo/cli/db.py
+++ b/chanjo/cli/db.py
@@ -59,9 +59,7 @@ def samples(context, group_id, sample_id, pretty):
     indent = None
     if pretty:
         indent = 4
-    click.echo(
-        json.dumps([dict(result) for result in query], default=str, indent=indent)
-    )
+    click.echo(json.dumps([dict(result) for result in query], default=str, indent=indent))
 
 
 @db_cmd.command()
@@ -75,9 +73,7 @@ def transcripts(context, sample_id, pretty):
     indent = None
     if pretty:
         indent = 4
-    click.echo(
-        json.dumps([dict(result) for result in query], default=str, indent=indent)
-    )
+    click.echo(json.dumps([dict(result) for result in query], default=str, indent=indent))
 
 
 @db_cmd.command()

--- a/chanjo/cli/init.py
+++ b/chanjo/cli/init.py
@@ -1,24 +1,24 @@
 # -*- coding: utf-8 -*-
 import codecs
-from shutil import which
 import logging
+from pathlib import Path
+from shutil import which
 
 import click
-from pathlib import Path
 import yaml
 
+from chanjo.init.bootstrap import BED_NAME, DB_NAME, pull
+from chanjo.init.demo import DEMO_BED_NAME, setup_demo
 from chanjo.store.api import ChanjoDB
-from chanjo.init.bootstrap import pull, BED_NAME, DB_NAME
-from chanjo.init.demo import setup_demo, DEMO_BED_NAME
 
 LOG = logging.getLogger(__name__)
 
 
 @click.command()
-@click.option('-f', '--force', is_flag=True, help='overwrite existing files')
-@click.option('-d', '--demo', is_flag=True, help='copy demo files')
-@click.option('-a', '--auto', is_flag=True)
-@click.argument('root_dir', default='.', required=False)
+@click.option("-f", "--force", is_flag=True, help="overwrite existing files")
+@click.option("-d", "--demo", is_flag=True, help="copy demo files")
+@click.option("-a", "--auto", is_flag=True)
+@click.argument("root_dir", default=".", required=False)
 @click.pass_context
 def init(context, force, demo, auto, root_dir):
     """Bootstrap a new chanjo setup."""
@@ -26,11 +26,11 @@ def init(context, force, demo, auto, root_dir):
     root_path = Path(root_dir)
 
     LOG.info("setting up chanjo under: %s", root_path)
-    db_uri = context.obj.get('database')
+    db_uri = context.obj.get("database")
     db_uri = db_uri or "sqlite:///{}".format(root_path.joinpath(DB_NAME).resolve())
 
     # test setup of sambamba
-    sambamba_bin = which('sambamba')
+    sambamba_bin = which("sambamba")
     if sambamba_bin is None:  # pragma: no cover
         LOG.warning("'sambamba' command not found")
     else:
@@ -44,7 +44,7 @@ def init(context, force, demo, auto, root_dir):
         chanjo_db = ChanjoDB(db_uri)
         chanjo_db.set_up()
         is_bootstrapped = True
-    elif auto or click.confirm('Bootstrap HGNC transcript BED?'):
+    elif auto or click.confirm("Bootstrap HGNC transcript BED?"):
         pull(root_dir, force=force)
 
         LOG.info("configure new chanjo database: %s", db_uri)
@@ -54,13 +54,13 @@ def init(context, force, demo, auto, root_dir):
 
     # setup config file
     root_path.mkdir(parents=True, exist_ok=True)
-    conf_path = root_path.joinpath('chanjo.yaml')
-    with open(conf_path, 'w') as conf_handle:
-        data = {'database': db_uri}
+    conf_path = root_path.joinpath("chanjo.yaml")
+    with open(conf_path, "w") as conf_handle:
+        data = {"database": db_uri}
         LOG.info("writing config file: %s", conf_path)
         yaml.dump(data, conf_handle, default_flow_style=False)
 
     if is_bootstrapped:
-        click.echo('Chanjo bootstrap successful! Now run: ')
+        click.echo("Chanjo bootstrap successful! Now run: ")
         bed_path = root_path.joinpath(DEMO_BED_NAME if demo else BED_NAME)
         click.echo("chanjo --config {} link {}".format(conf_path, bed_path))

--- a/chanjo/cli/load.py
+++ b/chanjo/cli/load.py
@@ -1,17 +1,17 @@
 # -*- coding: utf-8 -*-
 import logging
 import sys
-
 from pathlib import Path
 
 import click
 from sqlalchemy.exc import IntegrityError
 
-from chanjo.store.api import ChanjoDB
 from chanjo.load.link import link_elements
 from chanjo.load.sambamba import load_transcripts
+from chanjo.store.api import ChanjoDB
 
 LOG = logging.getLogger(__name__)
+
 
 def validate_stdin(context, param, value):
     """Validate piped input contains some data.
@@ -20,62 +20,74 @@ def validate_stdin(context, param, value):
         click.BadParameter: if STDIN is empty
     """
     # check if input is a file or stdin
-    if value.name == '<stdin>' and sys.stdin.isatty():  # pragma: no cover
+    if value.name == "<stdin>" and sys.stdin.isatty():  # pragma: no cover
         # raise error if stdin is empty
-        raise click.BadParameter('you need to pipe something to stdin')
+        raise click.BadParameter("you need to pipe something to stdin")
     return value
 
 
 @click.command()
-@click.option('-s', '--sample', help='override sample id from file')
-@click.option('-g', '--group', help='id to group related samples')
-@click.option('-n', '--name', help='display name for sample')
-@click.option('-gn', '--group-name', help='display name for sample group')
-@click.option('-r', '--threshold', default=10,
-              help='completeness level to disqualify exons')
-@click.argument('bed_stream', callback=validate_stdin,
-                type=click.File(encoding='utf-8'), default='-', required=False)
+@click.option("-s", "--sample", help="override sample id from file")
+@click.option("-g", "--group", help="id to group related samples")
+@click.option("-n", "--name", help="display name for sample")
+@click.option("-gn", "--group-name", help="display name for sample group")
+@click.option("-r", "--threshold", default=10, help="completeness level to disqualify exons")
+@click.argument(
+    "bed_stream",
+    callback=validate_stdin,
+    type=click.File(encoding="utf-8"),
+    default="-",
+    required=False,
+)
 @click.pass_context
 def load(context, sample, group, name, group_name, threshold, bed_stream):
     """Load Sambamba output into the database for a sample."""
-    chanjo_db = ChanjoDB(uri=context.obj['database'])
+    chanjo_db = ChanjoDB(uri=context.obj["database"])
     source = str(Path(bed_stream.name).resolve())
 
-    result = load_transcripts(bed_stream, sample_id=sample, group_id=group,
-                              source=source, threshold=threshold)
+    result = load_transcripts(
+        bed_stream, sample_id=sample, group_id=group, source=source, threshold=threshold
+    )
 
     result.sample.name = name
     result.sample.group_name = group_name
     try:
         with chanjo_db.begin() as session:
             session.add(result.sample)
-            with click.progressbar(result.models, length=result.count,
-                                   label='loading transcripts') as bar:
+            with click.progressbar(
+                result.models, length=result.count, label="loading transcripts"
+            ) as bar:
                 for tx_model in bar:
                     session.add(tx_model)
 
     except IntegrityError as error:
-        LOG.error('sample already loaded, rolling back')
+        LOG.error("sample already loaded, rolling back")
         LOG.debug(error.args[0])
         context.abort()
 
 
 @click.command()
-@click.argument('bed_stream', callback=validate_stdin,
-                type=click.File(encoding='utf-8'), default='-', required=False)
+@click.argument(
+    "bed_stream",
+    callback=validate_stdin,
+    type=click.File(encoding="utf-8"),
+    default="-",
+    required=False,
+)
 @click.pass_context
 def link(context, bed_stream):
     """Link related genomic elements."""
-    chanjo_db = ChanjoDB(uri=context.obj['database'])
+    chanjo_db = ChanjoDB(uri=context.obj["database"])
     result = link_elements(bed_stream)
     try:
         with chanjo_db.begin() as session:
-            with click.progressbar(result.models, length=result.count,
-                                   label='adding transcripts') as bar:
+            with click.progressbar(
+                result.models, length=result.count, label="adding transcripts"
+            ) as bar:
                 for tx_model in bar:
                     session.add(tx_model)
 
     except IntegrityError:
-            LOG.exception('elements already linked?')
-            click.echo("use 'chanjo db setup --reset' to re-build")
-            context.abort()
+        LOG.exception("elements already linked?")
+        click.echo("use 'chanjo db setup --reset' to re-build")
+        context.abort()

--- a/chanjo/cli/sambamba.py
+++ b/chanjo/cli/sambamba.py
@@ -9,16 +9,33 @@ LOG = logging.getLogger(__name__)
 
 
 @click.command()
-@click.option('-r', '--regions', type=click.Path(exists=True), required=True,
-              help='Path to a bed file with exon coordinates')
-@click.option('-t', '--cov-threshold', 'cov_thresholds', multiple=True, type=int,
-              help=("multiple thresholds can be provided,"
-                    "for each one an extra column will be added,"
-                    "the percentage of bases in the region"
-                    "where coverage is more than this value"))
-@click.option('-o', '--outfile', type=click.Path(exists=False),
-              help='Specify path to a file where results should be stored.')
-@click.argument('bam_file', type=click.Path(exists=True))
+@click.option(
+    "-r",
+    "--regions",
+    type=click.Path(exists=True),
+    required=True,
+    help="Path to a bed file with exon coordinates",
+)
+@click.option(
+    "-t",
+    "--cov-threshold",
+    "cov_thresholds",
+    multiple=True,
+    type=int,
+    help=(
+        "multiple thresholds can be provided,"
+        "for each one an extra column will be added,"
+        "the percentage of bases in the region"
+        "where coverage is more than this value"
+    ),
+)
+@click.option(
+    "-o",
+    "--outfile",
+    type=click.Path(exists=False),
+    help="Specify path to a file where results should be stored.",
+)
+@click.argument("bam_file", type=click.Path(exists=True))
 @click.pass_context
 def sambamba(context, bam_file, regions, cov_thresholds, outfile):
     """Run Sambamba from chanjo."""
@@ -26,5 +43,5 @@ def sambamba(context, bam_file, regions, cov_thresholds, outfile):
     try:
         run_sambamba(bam_file, regions, outfile, cov_thresholds)
     except Exception:
-        LOG.exception('something went really wrong :_(')
+        LOG.exception("something went really wrong :_(")
         context.abort()

--- a/chanjo/cli/sex.py
+++ b/chanjo/cli/sex.py
@@ -9,18 +9,17 @@ LOG = logging.getLogger(__name__)
 
 
 @click.command()
-@click.option('-p', '--prefix', default='', help='chromosome prefix')
-@click.argument('bam_path', type=click.Path(exists=True))
+@click.option("-p", "--prefix", default="", help="chromosome prefix")
+@click.argument("bam_path", type=click.Path(exists=True))
 @click.pass_context
 def sex(context, prefix, bam_path):
     """Guess the sex of a BAM alignment."""
     try:
         result = sex_from_bam(bam_path, prefix=prefix)
     except Exception:
-        LOG.exception('Something went really wrong :(')
+        LOG.exception("Something went really wrong :(")
         context.abort()
 
     # print the results to the console for pipeability (csv)
-    click.echo("#{prefix}X_coverage\t{prefix}Y_coverage\tsex"
-               .format(prefix=prefix))
-    click.echo('\t'.join(map(str, result)))
+    click.echo("#{prefix}X_coverage\t{prefix}Y_coverage\tsex".format(prefix=prefix))
+    click.echo("\t".join(map(str, result)))

--- a/chanjo/init/bootstrap.py
+++ b/chanjo/init/bootstrap.py
@@ -1,20 +1,18 @@
 # -*- coding: utf-8 -*-
 import logging
-import zipfile
 import sys
-
+import zipfile
 from pathlib import Path
 
-if sys.version_info[0] >=3:
+if sys.version_info[0] >= 3:
     from urllib.request import urlretrieve
 else:
     from urllib import urlretrieve
 
 
-
-DB_NAME = 'chanjo.coverage.sqlite3'
-BED_NAME = 'hgnc.grch37p13.exons.bed'
-BED_URL = 'https://s3.eu-central-1.amazonaws.com/clinical-assets/hgnc.grch37p13.exons.bed.zip'
+DB_NAME = "chanjo.coverage.sqlite3"
+BED_NAME = "hgnc.grch37p13.exons.bed"
+BED_URL = "https://s3.eu-central-1.amazonaws.com/clinical-assets/hgnc.grch37p13.exons.bed.zip"
 
 logger = logging.getLogger(__name__)
 
@@ -26,7 +24,7 @@ def pull(target_dir, force=False):  # pragma: no cover
         target_dir (path): relative path the folder to download to
         force (Optional[bool]): whether to overwrite existing files
     """
-    logger.debug('ensure target directory exists')
+    logger.debug("ensure target directory exists")
     target_path = Path(target_dir)
     target_path.mkdir(parents=True, exist_ok=True)
 
@@ -34,14 +32,14 @@ def pull(target_dir, force=False):  # pragma: no cover
     final_bed = target_path.joinpath(BED_NAME)
 
     if not final_bed.exists() or force:
-        logger.info('downloading... [%s]', BED_URL)
+        logger.info("downloading... [%s]", BED_URL)
         urlretrieve(BED_URL, bed_zip_path)
 
-        logger.info('extracting BED file...')
-        zip_ref = zipfile.ZipFile(bed_zip_path, 'r')
+        logger.info("extracting BED file...")
+        zip_ref = zipfile.ZipFile(bed_zip_path, "r")
         zip_ref.extractall(target_dir)
 
-        logger.info('removing BED archive...')
+        logger.info("removing BED archive...")
         bed_zip_path.unlink()
     else:
-        logger.warn('file already exists, skipping: %s', final_bed)
+        logger.warn("file already exists, skipping: %s", final_bed)

--- a/chanjo/init/demo.py
+++ b/chanjo/init/demo.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-from errno import EEXIST
 import logging
 import shutil
+from errno import EEXIST
 from pathlib import Path
 
 try:
@@ -10,8 +10,9 @@ except ImportError:  # Backport support for importlib metadata on Python 3.7
     from importlib_resources import files
 
 
-DEMO_BED_NAME = 'hgnc.min.bed'
+DEMO_BED_NAME = "hgnc.min.bed"
 log = logging.getLogger(__name__)
+
 
 def setup_demo(location, force=False):
     """Copy demo files to a directory.
@@ -19,10 +20,10 @@ def setup_demo(location, force=False):
     LOCATION: directory to add demo files to (default: ./chanjo-demo)
     """
     target_dir = Path(location)
-    pkg_dir = __name__.rpartition('.')[0]
+    pkg_dir = __name__.rpartition(".")[0]
 
     # Get the demo-files directory path using importlib.resources
-    demo_dir = files(pkg_dir) / 'demo-files'
+    demo_dir = files(pkg_dir) / "demo-files"
 
     if not demo_dir.is_dir():
         log.error("Demo files directory does not exist")
@@ -33,16 +34,16 @@ def setup_demo(location, force=False):
         target_file_path = target_dir / demo_file.name
         if not force and target_file_path.exists():
             log.error("%s exists, pick a different location", target_file_path)
-            raise OSError(EEXIST, 'file already exists', target_file_path)
+            raise OSError(EEXIST, "file already exists", target_file_path)
 
     try:
         # Copy the directory tree
         shutil.copytree(demo_dir, target_dir)
     except FileExistsError:
-        log.warning('Location must be a non-existing directory')
+        log.warning("Location must be a non-existing directory")
         raise
     except OSError as error:
-        log.error('An error occurred during file copying: %s', error)
+        log.error("An error occurred during file copying: %s", error)
         raise
 
     # Inform the user

--- a/chanjo/load/link.py
+++ b/chanjo/load/link.py
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
-from collections import namedtuple
 import logging
+from collections import namedtuple
 
 from chanjo.store.models import Transcript
+
 from .parse import bed as parse_bed
 from .utils import groupby_tx
 
-Result = namedtuple('Result', ['models', 'count'])
+Result = namedtuple("Result", ["models", "count"])
 log = logging.getLogger(__name__)
 
 
@@ -36,11 +37,15 @@ def make_model(transcript_id, exons):
         Transcript: uncommitted transcript model
     """
     # assume the same chromosome and gene for all exons
-    chromosome = exons[0]['chrom']
-    gene_id = int(exons[0]['elements'][transcript_id]['gene_id'])
-    gene_symbol = exons[0]['elements'][transcript_id]['symbol']
-    tot_length = sum((exon['chromEnd'] - exon['chromStart']) for exon in exons)
-    tx_model = Transcript(id=transcript_id, chromosome=chromosome,
-                          length=tot_length, gene_id=gene_id,
-                          gene_name=gene_symbol)
+    chromosome = exons[0]["chrom"]
+    gene_id = int(exons[0]["elements"][transcript_id]["gene_id"])
+    gene_symbol = exons[0]["elements"][transcript_id]["symbol"]
+    tot_length = sum((exon["chromEnd"] - exon["chromStart"]) for exon in exons)
+    tx_model = Transcript(
+        id=transcript_id,
+        chromosome=chromosome,
+        length=tot_length,
+        gene_id=gene_id,
+        gene_name=gene_symbol,
+    )
     return tx_model

--- a/chanjo/load/parse/bed.py
+++ b/chanjo/load/parse/bed.py
@@ -12,8 +12,8 @@ def chanjo(handle):
     Yields:
         dict: representation of row in BED file
     """
-    lines = (line.strip() for line in handle if not line.startswith('#'))
-    rows = (line.split('\t') for line in lines)
+    lines = (line.strip() for line in handle if not line.startswith("#"))
+    rows = (line.split("\t") for line in lines)
     for row in rows:
         yield expand_row(row)
 
@@ -31,20 +31,16 @@ def expand_row(row):
         BedFormattingError: failure to parse first three columns
     """
     try:
-        data = {
-            'chrom': row[0],
-            'chromStart': int(row[1]),
-            'chromEnd': int(row[2])
-        }
+        data = {"chrom": row[0], "chromStart": int(row[1]), "chromEnd": int(row[2])}
     except IndexError:
-        raise BedFormattingError('make sure fields are tab-separated')
+        raise BedFormattingError("make sure fields are tab-separated")
     except ValueError:
         raise BedFormattingError("positions malformatted: {}".format(row))
 
-    data['name'] = list_get(row, 3)
+    data["name"] = list_get(row, 3)
     element_combos = extra_fields(row[4:7])
-    data['elements'] = element_combos
-    data['extra_fields'] = row[7:]
+    data["elements"] = element_combos
+    data["extra_fields"] = row[7:]
     return data
 
 
@@ -60,9 +56,9 @@ def extra_fields(columns):
         List[tuple]: list of tuples with paired elements
     """
     try:
-        transcripts = columns[0].split(',')
-        genes = columns[1].split(',')
-        symbols = columns[2].split(',')
+        transcripts = columns[0].split(",")
+        genes = columns[1].split(",")
+        symbols = columns[2].split(",")
     except IndexError:
         return []
     return zip(transcripts, genes, symbols)

--- a/chanjo/load/parse/sambamba.py
+++ b/chanjo/load/parse/sambamba.py
@@ -18,11 +18,11 @@ def depth_output(handle):
         BedFormattingError: if the BED file doesn't contain enough columns
     """
     lines = (line.strip() for line in handle)
-    rows = (line.split('\t') for line in lines)
+    rows = (line.split("\t") for line in lines)
     # expect only a single header row
     header_row = next(rows)
     if len(header_row) < 6:
-        raise BedFormattingError('make sure fields are tab-separated')
+        raise BedFormattingError("make sure fields are tab-separated")
     header_data = expand_header(header_row)
     # parse rows
     for row in rows:
@@ -39,17 +39,18 @@ def expand_header(row):
         dict: name/index combos for fields
     """
     # figure out where the sambamba output begins
-    sambamba_start = row.index('readCount')
-    sambamba_end = row.index('sampleName')
-    coverage_columns = row[sambamba_start + 2:sambamba_end]
-    thresholds = {int(column.replace('percentage', '')): row.index(column)
-                  for column in coverage_columns}
+    sambamba_start = row.index("readCount")
+    sambamba_end = row.index("sampleName")
+    coverage_columns = row[sambamba_start + 2 : sambamba_end]
+    thresholds = {
+        int(column.replace("percentage", "")): row.index(column) for column in coverage_columns
+    }
     keys = {
-        'readCount': sambamba_start,
-        'meanCoverage': sambamba_start + 1,
-        'thresholds': thresholds,
-        'sampleName': sambamba_end,
-        'extraFields': slice(3, sambamba_start)
+        "readCount": sambamba_start,
+        "meanCoverage": sambamba_start + 1,
+        "thresholds": thresholds,
+        "sampleName": sambamba_end,
+        "extraFields": slice(3, sambamba_start),
     }
     return keys
 
@@ -64,16 +65,15 @@ def expand_row(header, row):
     Returns:
         dict: parsed sambamba output row
     """
-    thresholds = {threshold: float(row[key])
-                  for threshold, key in header['thresholds'].items()}
+    thresholds = {threshold: float(row[key]) for threshold, key in header["thresholds"].items()}
     data = {
-        'chrom': row[0],
-        'chromStart': int(row[1]),
-        'chromEnd': int(row[2]),
-        'sampleName': row[header['sampleName']],
-        'readCount': int(row[header['readCount']]),
-        'meanCoverage': float(row[header['meanCoverage']]),
-        'thresholds': thresholds,
-        'extraFields': row[header['extraFields']]
+        "chrom": row[0],
+        "chromStart": int(row[1]),
+        "chromEnd": int(row[2]),
+        "sampleName": row[header["sampleName"]],
+        "readCount": int(row[header["readCount"]]),
+        "meanCoverage": float(row[header["meanCoverage"]]),
+        "thresholds": thresholds,
+        "extraFields": row[header["extraFields"]],
     }
     return data

--- a/chanjo/load/sambamba.py
+++ b/chanjo/load/sambamba.py
@@ -1,12 +1,14 @@
 # -*- coding: utf-8 -*-
 from __future__ import division
+
 from collections import namedtuple
 
-from chanjo.store.models import TranscriptStat, Sample, Exon
+from chanjo.store.models import Exon, Sample, TranscriptStat
+
 from .parse import sambamba
 from .utils import groupby_tx
 
-Result = namedtuple('Result', ['models', 'count', 'sample'])
+Result = namedtuple("Result", ["models", "count", "sample"])
 
 
 def load_transcripts(sequence, sample_id=None, group_id=None, source=None, threshold=None):
@@ -24,15 +26,15 @@ def load_transcripts(sequence, sample_id=None, group_id=None, source=None, thres
     """
     exons = sambamba.depth_output(sequence)
     transcripts = groupby_tx(exons, sambamba=True)
-    raw_stats = ((tx_id, tx_stat(tx_id, exons, threshold=threshold))
-                 for tx_id, exons in transcripts.items())
+    raw_stats = (
+        (tx_id, tx_stat(tx_id, exons, threshold=threshold)) for tx_id, exons in transcripts.items()
+    )
 
     if sample_id is None:
-        sample_id = next(iter(transcripts.values()))[0]['sampleName']
+        sample_id = next(iter(transcripts.values()))[0]["sampleName"]
     sample_obj = Sample(id=sample_id, group_id=group_id, source=source)
 
-    models = (make_model(sample_obj, tx_id, raw_stat) for tx_id, raw_stat
-              in raw_stats)
+    models = (make_model(sample_obj, tx_id, raw_stat) for tx_id, raw_stat in raw_stats)
     return Result(models=models, count=len(transcripts), sample=sample_obj)
 
 
@@ -47,33 +49,34 @@ def tx_stat(transcript_id, exons, threshold=None):
     Returns:
         dict: aggregated stats over all exons
     """
-    sums = {'bases': 0, 'mean_coverage': 0}
+    sums = {"bases": 0, "mean_coverage": 0}
     incomplete_exons = []
 
     # for each of the exons (linked to one transcript)
     for exon in exons:
         # go over each of the fields to sum up
-        exon_length = (exon['chromEnd'] - exon['chromStart'])
-        sums['bases'] += exon_length
-        sums['mean_coverage'] += (exon['meanCoverage'] * exon_length)
+        exon_length = exon["chromEnd"] - exon["chromStart"]
+        sums["bases"] += exon_length
+        sums["mean_coverage"] += exon["meanCoverage"] * exon_length
 
         # add to the total sum for completeness levels
         for comp_key in [10, 15, 20, 50, 100]:
-            if comp_key in exon['thresholds']:
+            if comp_key in exon["thresholds"]:
                 sums_key = "completeness_{}".format(comp_key)
                 if sums_key not in sums:
                     sums[sums_key] = 0
-                completeness = exon['thresholds'][comp_key]
-                sums[sums_key] += (completeness * exon_length)
+                completeness = exon["thresholds"][comp_key]
+                sums[sums_key] += completeness * exon_length
 
                 if threshold == comp_key and completeness < 100:
-                    exon_obj = Exon(exon['chrom'], exon['chromStart'],
-                                    exon['chromEnd'], completeness)
+                    exon_obj = Exon(
+                        exon["chrom"], exon["chromStart"], exon["chromEnd"], completeness
+                    )
                     incomplete_exons.append(exon_obj)
 
-    fields = {key: (value / sums['bases']) for key, value in sums.items() if key != 'bases'}
-    fields['incomplete_exons'] = incomplete_exons
-    fields['threshold'] = threshold
+    fields = {key: (value / sums["bases"]) for key, value in sums.items() if key != "bases"}
+    fields["incomplete_exons"] = incomplete_exons
+    fields["threshold"] = threshold
     return fields
 
 

--- a/chanjo/load/utils.py
+++ b/chanjo/load/utils.py
@@ -6,20 +6,20 @@ def groupby_tx(exons, sambamba=False):
     transcripts = {}
     for exon in exons:
         if sambamba:
-            ids = zip(exon['extraFields'][-3].split(','),
-                      exon['extraFields'][-2].split(','),
-                      exon['extraFields'][-1].split(','))
+            ids = zip(
+                exon["extraFields"][-3].split(","),
+                exon["extraFields"][-2].split(","),
+                exon["extraFields"][-1].split(","),
+            )
         else:
-            ids = exon['elements']
+            ids = exon["elements"]
         elements = {}
         for tx_id, gene_id, symbol in ids:
             elements[tx_id] = dict(symbol=symbol, gene_id=gene_id)
-        exon['elements'] = elements
+        exon["elements"] = elements
 
-        for transcript_id in exon['elements']:
+        for transcript_id in exon["elements"]:
             if transcript_id not in transcripts:
                 transcripts[transcript_id] = []
             transcripts[transcript_id].append(exon)
     return transcripts
-
-

--- a/chanjo/sambamba.py
+++ b/chanjo/sambamba.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import logging
 import subprocess
-
 from subprocess import CalledProcessError
 
 log = logging.getLogger(__name__)
@@ -16,23 +15,24 @@ def run_sambamba(bam_file, region_file, outfile=None, cov_thresholds=()):
         outfile (Optional[Path]): file to write to (otherwise STDOUT)
         cov_thresholds (Optional[List[int]]): levels to sample completeness at
     """
-    sambamba_call = ['sambamba', 'depth', 'region', '--regions', region_file, bam_file]
+    sambamba_call = ["sambamba", "depth", "region", "--regions", region_file, bam_file]
 
     if outfile:
-        sambamba_call += ['-o', outfile]
+        sambamba_call += ["-o", outfile]
 
     for coverage_threshold in cov_thresholds:
-        sambamba_call += ['-T', str(coverage_threshold)]
+        sambamba_call += ["-T", str(coverage_threshold)]
 
-    log.info("Running sambamba with call: %s", ' '.join(sambamba_call))
+    log.info("Running sambamba with call: %s", " ".join(sambamba_call))
     try:
         subprocess.check_call(sambamba_call)  # stderr=log_stream
     except OSError as error:
         log.critical("sambamba seems to not exist on your system.")
         raise error
     except CalledProcessError as error:  # pragma: no cover
-        log.critical("Something went wrong when running sambamba. "
-                     "Please see sambamba error output.")
+        log.critical(
+            "Something went wrong when running sambamba. " "Please see sambamba error output."
+        )
         raise error
 
     log.debug("sambamba ran successfully")

--- a/chanjo/sex.py
+++ b/chanjo/sex.py
@@ -6,13 +6,14 @@ Based on the ratio between the average coverage across chromosomes it
 makes a simple sex prediction.
 """
 from __future__ import division
-from collections import namedtuple
+
 import logging
 import subprocess
+from collections import namedtuple
 
 LOG = logging.getLogger(__name__)
 
-SexGuess = namedtuple('SexGuess', ['x_coverage', 'y_coverage', 'sex'])
+SexGuess = namedtuple("SexGuess", ["x_coverage", "y_coverage", "sex"])
 
 
 def predict_sex(x_coverage, y_coverage):
@@ -30,20 +31,20 @@ def predict_sex(x_coverage, y_coverage):
         str: prediction, ['male', 'female', 'unknown']
     """
     if y_coverage == 0:
-        return 'female'
+        return "female"
     else:
         ratio = x_coverage / y_coverage
         if x_coverage == 0 or (ratio > 12 and ratio < 100):
-            return 'unknown'
+            return "unknown"
         elif ratio <= 12:
             # this is the entire prediction, it's usually very obvious
-            return 'male'
+            return "male"
         else:
             # the few reads mapping to the Y chromosomes are artifacts
-            return 'female'
+            return "female"
 
 
-def sex_from_bam(bam_path, prefix=''):
+def sex_from_bam(bam_path, prefix=""):
     """Predict the sex from a BAM alignment file.
 
     Args:
@@ -63,15 +64,14 @@ def sex_from_bam(bam_path, prefix=''):
     for region in regions:
         command = ["sambamba depth region -L {} {}".format(region, bam_path)]
         LOG.debug("calling: %s", command)
-        bed_out = subprocess.check_output(command, shell=True).decode('utf-8')
-        bed_rows = [line.split() for line in bed_out.splitlines()
-                    if not line.startswith('#')]
+        bed_out = subprocess.check_output(command, shell=True).decode("utf-8")
+        bed_rows = [line.split() for line in bed_out.splitlines() if not line.startswith("#")]
         if len(bed_rows) == 1:
             averages.append(float(bed_rows[0][4]))
         else:
-            chromosome = region.split(':')[0]
+            chromosome = region.split(":")[0]
             LOG.warning("couldn't find any reads on %s-chromosome", chromosome)
-            averages.append(0.)
+            averages.append(0.0)
 
     # make the guess
     x_coverage, y_coverage = list(averages)

--- a/chanjo/store/api.py
+++ b/chanjo/store/api.py
@@ -1,23 +1,27 @@
 # -*- coding: utf-8 -*-
 from __future__ import division
+
 import logging
 import os
-
 from pathlib import Path
 
 from sqlservice import Database
+
 from chanjo.calculate import CalculateMixin
-from .models import BASE
-from .fetch import FetchMixin
+
 from .delete import DeleteMixin
+from .fetch import FetchMixin
+from .models import BASE
 
 LOG = logging.getLogger(__name__)
+
 
 def get_absolute_path(db_uri):
     """Get the absolute path of the database URI."""
     # Use Path for handling paths
     db_path = Path(db_uri).expanduser().resolve()
     return db_path
+
 
 class ChanjoDB(Database, CalculateMixin, DeleteMixin, FetchMixin):
     """SQLAlchemy-based database object.
@@ -56,7 +60,6 @@ class ChanjoDB(Database, CalculateMixin, DeleteMixin, FetchMixin):
         if uri:
             self.connect(uri, debug=debug)
 
-
     def connect(self, db_uri, debug=False):
         """Configure connection to a SQL database.
 
@@ -64,15 +67,15 @@ class ChanjoDB(Database, CalculateMixin, DeleteMixin, FetchMixin):
             db_uri (str): path/URI to the database to connect to
             debug (Optional[bool]): whether to output logging information
         """
-        config = {'SQLALCHEMY_ECHO': debug}
-        if 'mysql' in db_uri:  # pragma: no cover
-            config['SQLALCHEMY_POOL_RECYCLE'] = 3600
-        elif '://' not in db_uri:
+        config = {"SQLALCHEMY_ECHO": debug}
+        if "mysql" in db_uri:  # pragma: no cover
+            config["SQLALCHEMY_POOL_RECYCLE"] = 3600
+        elif "://" not in db_uri:
             # expect only a path to a sqlite database
             db_path = get_absolute_path(db_uri)
             db_uri = "sqlite:///{}".format(db_path)
 
-        config['SQLALCHEMY_DATABASE_URI'] = db_uri
+        config["SQLALCHEMY_DATABASE_URI"] = db_uri
         super(ChanjoDB, self).__init__(db_uri, model_class=BASE)
 
     @property
@@ -95,7 +98,7 @@ class ChanjoDB(Database, CalculateMixin, DeleteMixin, FetchMixin):
         # create the tables
         self.create_all()
         tables = self.model_class.metadata.tables.keys()
-        LOG.info("created tables: %s", ', '.join(tables))
+        LOG.info("created tables: %s", ", ".join(tables))
         return self
 
     def tear_down(self):

--- a/chanjo/store/constants.py
+++ b/chanjo/store/constants.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 COMPLETENESS_LEVELS = [10, 15, 20, 50, 100]
-COMPLETENESS_COLUMNS = [
-    "completeness_{}".format(level) for level in COMPLETENESS_LEVELS
-]
+COMPLETENESS_COLUMNS = ["completeness_{}".format(level) for level in COMPLETENESS_LEVELS]
 STAT_COLUMNS = ["mean_coverage"] + COMPLETENESS_COLUMNS
 OMIM_GENE_IDS = [
     "24576",

--- a/chanjo/store/delete.py
+++ b/chanjo/store/delete.py
@@ -1,13 +1,13 @@
 """Module for deleting from database"""
 
 import logging
+
 from chanjo.store.models import Sample
 
 LOG = logging.getLogger(__name__)
 
 
 class DeleteMixin:
-
     """Methods for deleting samples from database"""
 
     def delete_sample(self, sample_id):

--- a/chanjo/store/fetch.py
+++ b/chanjo/store/fetch.py
@@ -4,12 +4,11 @@ from chanjo.store.models import Sample, TranscriptStat
 
 
 class FetchMixin:
-
     """Methods for fetching from database"""
 
     def fetch_samples(self, sample_id=None, group_id=None):
         """
-            Fetch samples from database
+        Fetch samples from database
         """
         with self.begin() as session:
             query = session.query(Sample)
@@ -21,10 +20,8 @@ class FetchMixin:
 
     def fetch_transcripts(self, sample_id):
         """
-            Fetch transcripts from database
+        Fetch transcripts from database
         """
         with self.begin() as session:
-            query = session.query(TranscriptStat).filter(
-                TranscriptStat.sample_id == sample_id
-            )
+            query = session.query(TranscriptStat).filter(TranscriptStat.sample_id == sample_id)
             return query

--- a/chanjo/testutils.py
+++ b/chanjo/testutils.py
@@ -1,18 +1,18 @@
-from pathlib import Path
-
 import logging
+from pathlib import Path
 
 LOG = logging.getLogger(__name__)
 
+
 def fake_urlretrieve(url, target):
-    open(target, 'a').close()
+    open(target, "a").close()
 
 
 class FakeZipFile(object):
 
-    def __init__(self, in_path, mode='r'):
+    def __init__(self, in_path, mode="r"):
         self.in_path = in_path
 
     def extractall(self, target_dir):
-        out_path = Path(target_dir).joinpath(self.in_path.name.replace('.zip', ''))
-        open(out_path, 'a').close()
+        out_path = Path(target_dir).joinpath(self.in_path.name.replace(".zip", ""))
+        open(out_path, "a").close()

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,3 +11,5 @@ docutils
 html-linter
 mkdocs
 markdown-include
+black
+isort

--- a/setup.py
+++ b/setup.py
@@ -4,27 +4,27 @@
 # To use a consistent encoding
 import codecs
 import os
-# Always prefer setuptools over distutils
-from setuptools import setup, find_packages
-from setuptools.command.test import test as TestCommand
 import sys
 
+# Always prefer setuptools over distutils
+from setuptools import find_packages, setup
+from setuptools.command.test import test as TestCommand
+
 # Shortcut for building/publishing to Pypi
-if sys.argv[-1] == 'publish':
-    os.system('python setup.py sdist bdist_wheel upload')
+if sys.argv[-1] == "publish":
+    os.system("python setup.py sdist bdist_wheel upload")
     sys.exit()
 
 
-def parse_reqs(req_path='./requirements.txt'):
+def parse_reqs(req_path="./requirements.txt"):
     """Recursively parse requirements from nested pip files."""
     install_requires = []
-    with codecs.open(req_path, 'r') as handle:
+    with codecs.open(req_path, "r") as handle:
         # remove comments and empty lines
-        lines = (line.strip() for line in handle
-                 if line.strip() and not line.startswith('#'))
+        lines = (line.strip() for line in handle if line.strip() and not line.startswith("#"))
         for line in lines:
             # check for nested requirements files
-            if line.startswith('-r'):
+            if line.startswith("-r"):
                 # recursively call this function
                 install_requires += parse_reqs(req_path=line[3:])
             else:
@@ -36,7 +36,6 @@ def parse_reqs(req_path='./requirements.txt'):
 # This is a plug-in for setuptools that will invoke py.test
 # when you run python setup.py test
 class PyTest(TestCommand):
-
     """Set up the py.test test runner."""
 
     def finalize_options(self):
@@ -49,78 +48,68 @@ class PyTest(TestCommand):
         """Execute the test runner command."""
         # Import here, because outside the required eggs aren't loaded yet
         import pytest
+
         sys.exit(pytest.main(self.test_args))
 
 
 setup(
-    name='chanjo',
-
+    name="chanjo",
     # Versions should comply with PEP440. For a discussion on
     # single-sourcing the version across setup.py and the project code,
     # see http://packaging.python.org/en/latest/tutorial.html#version
-    version='4.7.1',
-
-    description='Coverage analysis tool for clinical sequencing',
+    version="4.7.1",
+    description="Coverage analysis tool for clinical sequencing",
     # What does your project relate to? Separate with spaces.
-    keywords='coverage sequencing clinical exome completeness diagnostics',
-    author='Robin Andeer',
-    author_email='robin.andeer@gmail.com',
-    license='MIT',
-
+    keywords="coverage sequencing clinical exome completeness diagnostics",
+    author="Robin Andeer",
+    author_email="robin.andeer@gmail.com",
+    license="MIT",
     # The project's main homepage
-    url='https://clinical-genomics.github.io/chanjo/',
-
-    packages=find_packages(exclude=('tests*', 'docs', 'examples')),
-
+    url="https://clinical-genomics.github.io/chanjo/",
+    packages=find_packages(exclude=("tests*", "docs", "examples")),
     # If there are data files included in your packages that need to be
     # installed, specify them here.
     include_package_data=True,
-    package_data=dict(chanjo=['demo/files/*']),
+    package_data=dict(chanjo=["demo/files/*"]),
     zip_safe=False,
-
     # Install requirements loaded from ``requirements.txt``
     install_requires=parse_reqs(),
     tests_require=[
-        'pytest',
+        "pytest",
     ],
     cmdclass=dict(test=PyTest),
-
     # To provide executable scripts, use entry points in preference to the
     # "scripts" keyword. Entry points provide cross-platform support and
     # allow pip to create the appropriate form of executable for the
     # target platform.
     entry_points={
-        'console_scripts': [
-            'chanjo = chanjo.cli:root',
+        "console_scripts": [
+            "chanjo = chanjo.cli:root",
         ],
-        'chanjo.subcommands.4': [
-            'init = chanjo.cli:init',
-            'sex = chanjo.cli:sex',
-            'sambamba = chanjo.cli:sambamba',
-            'db = chanjo.cli:db_cmd',
-            'load = chanjo.cli:load',
-            'link = chanjo.cli:link',
-            'calculate = chanjo.cli:calculate',
-        ]
+        "chanjo.subcommands.4": [
+            "init = chanjo.cli:init",
+            "sex = chanjo.cli:sex",
+            "sambamba = chanjo.cli:sambamba",
+            "db = chanjo.cli:db_cmd",
+            "load = chanjo.cli:load",
+            "link = chanjo.cli:link",
+            "calculate = chanjo.cli:calculate",
+        ],
     },
-
     # See: http://pypi.python.org/pypi?%3Aaction=list_classifiers
     classifiers=[
         # How mature is this project? Common values are:
         #   3 - Alpha
         #   4 - Beta
         #   5 - Production/Stable
-        'Development Status :: 5 - Production/Stable',
-
+        "Development Status :: 5 - Production/Stable",
         # Indicate who your project is intended for
-        'Intended Audience :: Science/Research',
-        'Topic :: Software Development',
-        'Topic :: Scientific/Engineering :: Bio-Informatics',
-
+        "Intended Audience :: Science/Research",
+        "Topic :: Software Development",
+        "Topic :: Scientific/Engineering :: Bio-Informatics",
         # Pick your license as you wish (should match "license" above)
-        'License :: OSI Approved :: MIT License',
-
-        'Programming Language :: Python :: 3',
-        'Environment :: Console',
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python :: 3",
+        "Environment :: Console",
     ],
 )

--- a/tasks.py
+++ b/tasks.py
@@ -7,38 +7,39 @@ from invoke.util import log
 @task
 def test(context, track=False):
     """Run the test runner."""
-    command = ('py.test --cov-report html --cov "$(basename "$PWD")" tests/ '
-               '--verbose --color=yes -s')
-    command += ' --ipdb' if track else ' --looponfail'
+    command = (
+        'py.test --cov-report html --cov "$(basename "$PWD")" tests/ ' "--verbose --color=yes -s"
+    )
+    command += " --ipdb" if track else " --looponfail"
     run(command, pty=True)
 
 
 @task
 def clean(context):
     """clean - remove build artifacts."""
-    run('rm -rf build/')
-    run('rm -rf dist/')
-    run('rm -rf chanjo.egg-info')
+    run("rm -rf build/")
+    run("rm -rf dist/")
+    run("rm -rf chanjo.egg-info")
     run("find . -name '*.pyc' -delete")
     run("find . -name '*.pyo' -delete")
     run("find . -name '*~' -delete")
-    run('find . -name __pycache__ -delete')
-    log.info('cleaned up')
+    run("find . -name __pycache__ -delete")
+    log.info("cleaned up")
 
 
 @task(clean)
 def publish(context):
     """Publish to the cheeseshop."""
-    run('python setup.py sdist upload', pty=True)
-    run('python setup.py bdist_wheel upload', pty=True)
-    log.info('published new release')
+    run("python setup.py sdist upload", pty=True)
+    run("python setup.py bdist_wheel upload", pty=True)
+    log.info("published new release")
 
 
 @task
 def coverage(context):
     """Run test coverage check and open HTML report."""
-    run('coverage run --source chanjo setup.py test')
-    run('coverage report -m')
-    run('coverage html')
-    run('open htmlcov/index.html')
-    log.info('collected test coverage stats')
+    run("coverage run --source chanjo setup.py test")
+    run("coverage report -m")
+    run("coverage html")
+    run("open htmlcov/index.html")
+    log.info("collected test coverage stats")

--- a/tests/cli/test_cli_base.py
+++ b/tests/cli/test_cli_base.py
@@ -8,8 +8,8 @@ def test_logging_to_file(tmp_path, invoke_cli):
     # GIVEN an empty directory
     assert not list(tmp_path.iterdir())
     # WHEN running the CLI to display some help for a subcommand
-    log_path = tmp_path.joinpath('stderr.log')
-    result = invoke_cli(['--log-file', str(log_path), 'db'])
+    log_path = tmp_path.joinpath("stderr.log")
+    result = invoke_cli(["--log-file", str(log_path), "db"])
     assert result.exit_code == 0
     assert list(tmp_path.iterdir()) == [log_path]
 
@@ -23,20 +23,20 @@ def test_list_commands(invoke_cli):
 
 def test_missing_command(invoke_cli):
     # WHEN invoking a missing command
-    result = invoke_cli(['idontexist'])
+    result = invoke_cli(["idontexist"])
     # THEN context should abort
     assert result.exit_code != 0
 
 
 def test_with_config(tmpdir, invoke_cli):
     # GIVEN a simple config file
-    conf_path = str(tmpdir.join('chanjo.yaml'))
-    db_path = str(tmpdir.join('coverage.sqlite3'))
-    data = {'database': db_path}
-    with open(conf_path, 'w') as handle:
+    conf_path = str(tmpdir.join("chanjo.yaml"))
+    db_path = str(tmpdir.join("coverage.sqlite3"))
+    data = {"database": db_path}
+    with open(conf_path, "w") as handle:
         yaml.dump(data, handle, default_flow_style=False)
     # WHEN launching CLI with config
-    result = invoke_cli(['-c', conf_path, 'db', 'setup'])
+    result = invoke_cli(["-c", conf_path, "db", "setup"])
     # THEN config values should be picked up
     assert result.exit_code == 0
     assert os.path.exists(db_path)

--- a/tests/cli/test_cli_calculate.py
+++ b/tests/cli/test_cli_calculate.py
@@ -1,9 +1,10 @@
 """Test calculate subcommand"""
+
 import json
 
 from chanjo.cli import root
-from chanjo.store.models import Sample
 from chanjo.cli.calculate import dump_json
+from chanjo.store.models import Sample
 
 
 def test_mean(popexist_db, cli_runner):
@@ -11,26 +12,26 @@ def test_mean(popexist_db, cli_runner):
         # GIVEN an existing database with one sample
         assert session.first(Sample.select())
         # WHEN assessing the mean values metrics per sample
-        res = cli_runner.invoke(root, ['-d', popexist_db.uri, 'calculate', 'mean'])
+        res = cli_runner.invoke(root, ["-d", popexist_db.uri, "calculate", "mean"])
         # THEN the command should return JSON results
         assert res.exit_code == 0
         # ... returns some debug info to STDERR that we strip away
-        lines = res.output.strip().split('\n')
+        lines = res.output.strip().split("\n")
         assert len(lines) == 1
         # ... the last row (no incl. empty line) is JSON formatted
         data = json.loads(lines[0].strip())
-        assert data['sample_id'] == 'sample'
-        assert isinstance(data['mean_coverage'], float)
+        assert data["sample_id"] == "sample"
+        assert isinstance(data["mean_coverage"], float)
 
 
 def test_dump_json():
     # GIVEN some dict
-    data = {'name': 'PT Anderson', 'age': 45}
+    data = {"name": "PT Anderson", "age": 45}
     # WHEN dumping to JSON with pretty-option enabled
     json_str = dump_json(data, pretty=True)
     # THEN the output is formatted over multiple lines
     assert isinstance(json_str, str)
-    assert len(json_str.split('\n')) == 4
+    assert len(json_str.split("\n")) == 4
 
 
 def test_coverage(popexist_db, cli_runner):
@@ -39,14 +40,15 @@ def test_coverage(popexist_db, cli_runner):
         # GIVEN an existing database with one sample
         assert session.first(Sample.select())
         # WHEN assessing the omim coverage per sample
-        res = cli_runner.invoke(root, ['-d', popexist_db.uri, 'calculate', 'coverage', '-s',
-                                       'sample', '14825'])
+        res = cli_runner.invoke(
+            root, ["-d", popexist_db.uri, "calculate", "coverage", "-s", "sample", "14825"]
+        )
         # THEN the command should return JSON results
         assert res.exit_code == 0
         # ... returns some debug info to STDERR that we strip away
-        lines = res.output.strip().split('\n')
+        lines = res.output.strip().split("\n")
         assert len(lines) == 1
         # ... the last row (no incl. empty line) is JSON formatted
         data = json.loads(lines[0].strip())
         # THE dict should include mean_coverage and mean completeness for sample
-        assert set(data['sample'].keys()) == set(['mean_coverage', 'mean_completeness'])
+        assert set(data["sample"].keys()) == set(["mean_coverage", "mean_completeness"])

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 from tempfile import gettempdir
 
-from mock import patch
 import yaml
+from mock import patch
 
 from chanjo.testutils import FakeZipFile, fake_urlretrieve
 
@@ -11,36 +11,36 @@ def test_init_demo(tmp_path, invoke_cli):
     # GIVEN empty directory
     assert not list(tmp_path.iterdir())
     # WHEN setting up demo on CLI
-    target_dir = tmp_path.joinpath('chanjo-demo')
+    target_dir = tmp_path.joinpath("chanjo-demo")
     target_path = str(target_dir)
-    result = invoke_cli(['init', '--demo', target_path])
+    result = invoke_cli(["init", "--demo", target_path])
     # THEN is should work and place 4 demo files + 1 sqlite db + 1 config
     assert result.exit_code == 0
     assert len(list(target_dir.iterdir())) == (4 + 1 + 1)
 
 
-@patch('urllib.request.urlretrieve', fake_urlretrieve)
-@patch('zipfile.ZipFile', FakeZipFile)
-@patch('click.confirm', lambda param: True)
+@patch("urllib.request.urlretrieve", fake_urlretrieve)
+@patch("zipfile.ZipFile", FakeZipFile)
+@patch("click.confirm", lambda param: True)
 def test_init_bootstrap(tmp_path, invoke_cli):
     # GIVEN empty dir
     assert not list(tmp_path.iterdir())
     # WHEN bootstrapping chanjo
-    result = invoke_cli(['init', str(tmp_path)])
+    result = invoke_cli(["init", str(tmp_path)])
     # THEN it should place 2 + 1 (BED, DB, config) files in the target dir
     assert result.exit_code == 0
     assert len(list(tmp_path.iterdir())) == 3
 
 
-@patch('click.confirm', lambda param: False)
-@patch('click.prompt', lambda param: "{}/cov.sqlite3".format(gettempdir()))
+@patch("click.confirm", lambda param: False)
+@patch("click.prompt", lambda param: "{}/cov.sqlite3".format(gettempdir()))
 def test_init_no_bootstrap(tmp_path, invoke_cli):
     # GIVEN ...
     # WHEN opting out of bootstrap
-    result = invoke_cli(['init', str(tmp_path)])
+    result = invoke_cli(["init", str(tmp_path)])
     # THEN it should work with custom database URI
     assert result.exit_code == 0
-    conf_path = tmp_path.joinpath('chanjo.yaml')
-    with open(str(conf_path), 'r') as handle:
+    conf_path = tmp_path.joinpath("chanjo.yaml")
+    with open(str(conf_path), "r") as handle:
         data = yaml.safe_load(handle)
-    assert 'coverage.sqlite3' in data['database']
+    assert "coverage.sqlite3" in data["database"]

--- a/tests/cli/test_cli_load.py
+++ b/tests/cli/test_cli_load.py
@@ -7,7 +7,7 @@ def test_load(existing_db, invoke_cli, sambamba_path):
     with existing_db.begin() as session:
         assert session.first(Sample.select()) is None
         db_uri = existing_db.uri
-        result = invoke_cli(['--database', db_uri, 'load', sambamba_path])
+        result = invoke_cli(["--database", db_uri, "load", sambamba_path])
         # WHEN loading into database
         assert result.exit_code == 0
         assert session.first(Sample.select())
@@ -16,12 +16,11 @@ def test_load(existing_db, invoke_cli, sambamba_path):
 def test_load_conflict(popexist_db, invoke_cli, sambamba_path):
     # GIVEN an existing database with a sample
     db_uri = popexist_db.uri
-    sample_id = 'sample'
+    sample_id = "sample"
     with popexist_db.begin() as session:
         assert session.first(Sample.select()).id == sample_id
         # WHEN you try to add the same sample id twice
-        result = invoke_cli(['--database', db_uri, 'load', '--sample', sample_id,
-                             sambamba_path])
+        result = invoke_cli(["--database", db_uri, "load", "--sample", sample_id, sambamba_path])
         # THEN it should fail
         assert result.exit_code != 0
         assert len(session.all(Sample.select())) == 1
@@ -31,14 +30,14 @@ def test_link(existing_db, invoke_cli, bed_path):
     # GIVEN chanjo bed file and an existing database
     db_uri = existing_db.uri
     # WHEN linking elements in the database
-    result = invoke_cli(['--database', db_uri, 'link', bed_path])
+    result = invoke_cli(["--database", db_uri, "link", bed_path])
     # THEN database should be populated with all transcripts
     assert result.exit_code == 0
     with existing_db.begin() as session:
         assert len(session.all(Transcript.select())) == 5
 
         # WHEN loading again...
-        result = invoke_cli(['--database', db_uri, 'link', bed_path])
+        result = invoke_cli(["--database", db_uri, "link", bed_path])
         # THEN it should error and rollback the session
         assert result.exit_code != 0
         assert len(session.all(Transcript.select())) == 5

--- a/tests/cli/test_cli_sambamba.py
+++ b/tests/cli/test_cli_sambamba.py
@@ -4,7 +4,7 @@
 def test_sambamba(invoke_cli, bam_path, bed_path):
     # GIVEN a small BAM file and corresponding BED file
     # WHEN running sambamba
-    result = invoke_cli(['sambamba', '-r', bed_path, bam_path])
+    result = invoke_cli(["sambamba", "-r", bed_path, bam_path])
     # THEN command should complete succesfully
     assert result.exit_code == 0
 
@@ -13,6 +13,6 @@ def test_sambamba_with_bai(invoke_cli, bam_path, bed_path):
     # GIVEN a BAI-file instead of BAM
     bai_path = "{}.bai".format(bam_path)
     # WHEN running sambamba
-    result = invoke_cli(['sambamba', '-r', bed_path, bai_path])
+    result = invoke_cli(["sambamba", "-r", bed_path, bai_path])
     # THEN command should exit with error
     assert result.exit_code != 0

--- a/tests/cli/test_cli_sex.py
+++ b/tests/cli/test_cli_sex.py
@@ -3,12 +3,12 @@ from chanjo.cli import root
 
 
 def test_sex(cli_runner, bam_path):
-    result = cli_runner.invoke(root, ['sex', bam_path])
+    result = cli_runner.invoke(root, ["sex", bam_path])
     assert result.exit_code == 0
-    assert 'female' in result.output
+    assert "female" in result.output
 
 
 def test_sex_with_wrong_file(cli_runner, bam_path):
     bai_path = "{}.bai".format(bam_path)
-    result = cli_runner.invoke(root, ['sex', bai_path])
+    result = cli_runner.invoke(root, ["sex", bai_path])
     assert result.exit_code != 0

--- a/tests/cli/test_cli_store.py
+++ b/tests/cli/test_cli_store.py
@@ -36,7 +36,10 @@ def test_remove(cli_runner, popexist_db):
         cli_runner.invoke(root, ["--database", popexist_db.uri, "db", "remove", sample_id])
         # THEN the sample should be deleted along with annotations
         assert session.first(Sample.select()) is None
-        assert len(session.all(TranscriptStat.select().where(TranscriptStat.sample_id == sample_id))) == 0
+        assert (
+            len(session.all(TranscriptStat.select().where(TranscriptStat.sample_id == sample_id)))
+            == 0
+        )
         # WHEN removing a sample with non-existing id
         result = cli_runner.invoke(
             root, ["--database", popexist_db.uri, "db", "remove", "no-sample-id"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,63 +1,65 @@
 # -*- coding: utf-8 -*-
 import codecs
-from functools import partial
 import os
+from functools import partial
 
-from click.testing import CliRunner
 import pytest
+from click.testing import CliRunner
 
 from chanjo.cli import root
-from chanjo.store.api import ChanjoDB
+from chanjo.load.link import link_elements
 from chanjo.load.parse import bed, sambamba
 from chanjo.load.sambamba import load_transcripts
-from chanjo.load.link import link_elements
+from chanjo.store.api import ChanjoDB
 
 
 @pytest.fixture
 def reset_path():
     """Reset PATH environment variable temporarily."""
-    path_env = os.environ['PATH']
-    os.environ['PATH'] = ''
+    path_env = os.environ["PATH"]
+    os.environ["PATH"] = ""
     yield path_env
-    os.environ['PATH'] = path_env
+    os.environ["PATH"] = path_env
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def chanjo_db():
-    _chanjo_db = ChanjoDB('sqlite://')
+    _chanjo_db = ChanjoDB("sqlite://")
     _chanjo_db.set_up()
     yield _chanjo_db
     _chanjo_db.tear_down()
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def existing_db(tmpdir):
-    db_path = tmpdir.join('coverage.sqlite3')
+    db_path = tmpdir.join("coverage.sqlite3")
     chanjo_db = ChanjoDB(str(db_path))
     chanjo_db.set_up()
     yield chanjo_db
     chanjo_db.tear_down()
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def popexist_db(existing_db, exon_lines):
     with existing_db.begin(expire_on_commit=False) as session:
         result = link_elements(exon_lines)
         session.add_all(result.models)
-        result = load_transcripts(exon_lines, sample_id='sample', group_id='group')
+        result = load_transcripts(exon_lines, sample_id="sample", group_id="group")
         session.add(result.sample)
         session.add_all(result.models)
     yield existing_db
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def populated_db(chanjo_db, exon_lines):
     exon_lines = list(exon_lines)
     result = link_elements(exon_lines)
     with chanjo_db.begin(expire_on_commit=False) as session:
         session.add_all(result.models)
-        results = [load_transcripts(exon_lines, sample_id='sample', group_id='group'),
-                   load_transcripts(exon_lines, sample_id='sample2', group_id='group')]
+        results = [
+            load_transcripts(exon_lines, sample_id="sample", group_id="group"),
+            load_transcripts(exon_lines, sample_id="sample2", group_id="group"),
+        ]
         for result in results:
             session.add(result.sample)
             session.add_all(result.models)
@@ -66,22 +68,21 @@ def populated_db(chanjo_db, exon_lines):
 
 @pytest.fixture
 def exon_lines(sambamba_path):
-    with codecs.open(sambamba_path, 'r', encoding='utf-8') as stream:
+    with codecs.open(sambamba_path, "r", encoding="utf-8") as stream:
         _exon_lines = [line for line in stream]
     return _exon_lines
 
 
 @pytest.fixture
 def bed_lines(bed_path):
-    with codecs.open(bed_path, 'r', encoding='utf-8') as stream:
+    with codecs.open(bed_path, "r", encoding="utf-8") as stream:
         _bed_lines = [line for line in stream]
     return _bed_lines
 
 
 @pytest.fixture
 def bed_row():
-    row = ['22', '32588888', '32589173', '22-32588888-32589173', 'CCDS54521.1',
-           'RFPL2']
+    row = ["22", "32588888", "32589173", "22-32588888-32589173", "CCDS54521.1", "RFPL2"]
     return row
 
 
@@ -110,17 +111,17 @@ def invoke_cli(cli_runner):
 
 @pytest.fixture
 def bam_path():
-    _bam_path = 'tests/fixtures/ccds-mini.sorted.bam'
+    _bam_path = "tests/fixtures/ccds-mini.sorted.bam"
     return _bam_path
 
 
 @pytest.fixture
 def bed_path():
-    _bed_path = 'tests/fixtures/ccds-mini.bed'
+    _bed_path = "tests/fixtures/ccds-mini.bed"
     return _bed_path
 
 
 @pytest.fixture
 def sambamba_path():
-    _sambamba_path = 'tests/fixtures/sambamba.depth.bed'
+    _sambamba_path = "tests/fixtures/sambamba.depth.bed"
     return _sambamba_path

--- a/tests/init/test_init_bootstrap.py
+++ b/tests/init/test_init_bootstrap.py
@@ -5,8 +5,8 @@ from chanjo.init import bootstrap
 from chanjo.testutils import FakeZipFile, fake_urlretrieve
 
 
-@patch('urllib.request.urlretrieve', fake_urlretrieve)
-@patch('zipfile.ZipFile', FakeZipFile)
+@patch("urllib.request.urlretrieve", fake_urlretrieve)
+@patch("zipfile.ZipFile", FakeZipFile)
 def test_pull(tmp_path):
     # GIVEN a target directory
     target_dir = str(tmp_path)

--- a/tests/init/test_init_demo.py
+++ b/tests/init/test_init_demo.py
@@ -8,11 +8,11 @@ from chanjo.init import demo
 
 def test_setup_demo(tmpdir):
     # GIVEN a non-existing target directory
-    target_dir = tmpdir.join('chanjo-demo')
+    target_dir = tmpdir.join("chanjo-demo")
     target_path = str(target_dir)
     demo.setup_demo(target_path)
     files = os.listdir(target_path)
-    expected_files = os.listdir('chanjo/init/demo-files')
+    expected_files = os.listdir("chanjo/init/demo-files")
     assert files == expected_files
 
     # GIVEN the files are already in place

--- a/tests/load/parse/test_load_parse_bed.py
+++ b/tests/load/parse/test_load_parse_bed.py
@@ -1,32 +1,32 @@
 # -*- coding: utf-8 -*-
 import pytest
 
-from chanjo.load.parse import bed
 from chanjo.exc import BedFormattingError
+from chanjo.load.parse import bed
 
 
 def test_expand_row(bed_row):
     data = bed.expand_row(bed_row)
-    assert data['name'] == bed_row[3]
+    assert data["name"] == bed_row[3]
 
     # test with malformatted values
     # GIVEN position is not int
-    bed_row[1] = 'paulthomas'
+    bed_row[1] = "paulthomas"
     with pytest.raises(BedFormattingError):
         bed.expand_row(bed_row)
 
 
 def test_expand_row_space_separated():
     with pytest.raises(BedFormattingError):
-        bed.expand_row(['22 32588888 32589173 22-32588888-32589173'])
+        bed.expand_row(["22 32588888 32589173 22-32588888-32589173"])
 
 
 def test_chanjo(bed_lines):
     exons = list(bed.chanjo(bed_lines))
     assert len(exons) == 19
     exon = exons[0]
-    assert exon['chrom'] == '1'
-    assert exon['name'] == '1-11-18'
+    assert exon["chrom"] == "1"
+    assert exon["name"] == "1-11-18"
 
 
 def test_extra_fields():

--- a/tests/load/parse/test_load_parse_sambamba.py
+++ b/tests/load/parse/test_load_parse_sambamba.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 import pytest
 
-from chanjo.load.parse import sambamba
 from chanjo.exc import BedFormattingError
+from chanjo.load.parse import sambamba
 
 
 def test_depth_output():
-    exon_lines = ['# chrom chromStart chromEnd\n', '1 10 100\n']
+    exon_lines = ["# chrom chromStart chromEnd\n", "1 10 100\n"]
     with pytest.raises(BedFormattingError):
         list(sambamba.depth_output(exon_lines))

--- a/tests/load/test_load_sambamba.py
+++ b/tests/load/test_load_sambamba.py
@@ -1,24 +1,23 @@
 # -*- coding: utf-8 -*-
-from chanjo.store.models import TranscriptStat
 from chanjo.load import sambamba
+from chanjo.store.models import TranscriptStat
 
 
 def test_load_transcripts(exon_lines):
     # GIVEN sambamba depth output lines
     # WHEN loading transcript stats
-    result = sambamba.load_transcripts(exon_lines, sample_id='sample',
-                                       group_id='group')
+    result = sambamba.load_transcripts(exon_lines, sample_id="sample", group_id="group")
     # THEN transcript models should be generated
     assert result.count == 9
-    assert result.sample.id == 'sample'
-    assert result.sample.group_id == 'group'
+    assert result.sample.id == "sample"
+    assert result.sample.group_id == "group"
     assert isinstance(list(result.models)[0], TranscriptStat)
 
     # GIVEN no explicit sample id
     # WHEN loading transcript stats
     result = sambamba.load_transcripts(exon_lines)
     # THEN it should be picked up from file
-    assert result.sample.id == 'ADM992A10'
+    assert result.sample.id == "ADM992A10"
 
 
 def test_load_transcripts_with_threshold(exon_lines):
@@ -27,6 +26,5 @@ def test_load_transcripts_with_threshold(exon_lines):
     # WHEN loading transcript stats
     result = sambamba.load_transcripts(exon_lines, threshold=threshold)
     # THEN some transcripts will have incomplete exons linked
-    incompletes = [transcript for transcript in result.models
-                   if transcript.incomplete_exons]
+    incompletes = [transcript for transcript in result.models if transcript.incomplete_exons]
     assert len(incompletes) > 0

--- a/tests/store/test_store_api.py
+++ b/tests/store/test_store_api.py
@@ -1,6 +1,7 @@
 """
     Tests for store
 """
+
 from datetime import datetime
 
 import pytest
@@ -105,7 +106,7 @@ def test_delete_sample(populated_db):
     sample_id = "sample"
     with populated_db.begin() as session:
         assert len(list(store.fetch_samples(sample_id=sample_id))) != 0
-        assert  session.all(TranscriptStat.select().where(TranscriptStat.sample_id == sample_id))
+        assert session.all(TranscriptStat.select().where(TranscriptStat.sample_id == sample_id))
         assert len(list(store.fetch_transcripts(sample_id=sample_id))) != 0
 
         # WHEN deleting a sample
@@ -113,7 +114,10 @@ def test_delete_sample(populated_db):
 
         # THEN that sample and all its transcripts are deleted from the database
         assert len(list(store.fetch_samples(sample_id=sample_id))) == 0
-        assert len(session.all(TranscriptStat.select().where(TranscriptStat.sample_id == sample_id))) == 0
+        assert (
+            len(session.all(TranscriptStat.select().where(TranscriptStat.sample_id == sample_id)))
+            == 0
+        )
         assert len(list(store.fetch_transcripts(sample_id=sample_id))) == 0
 
 

--- a/tests/store/test_store_models.py
+++ b/tests/store/test_store_models.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
-from chanjo.store.models import TranscriptStat, Exon
+from chanjo.store.models import Exon, TranscriptStat
 
 
 def test_TranscriptStat():
     # GIVEN a transcript stat with two incomplete exons
-    exons = [Exon('1', 10, 100, 99.1), Exon('1', 200, 300, 80.5)]
+    exons = [Exon("1", 10, 100, 99.1), Exon("1", 200, 300, 80.5)]
     stat = TranscriptStat(mean_coverage=10.3, incomplete_exons=exons)
     # WHEN accessing them
     parsed_exons = list(stat.incomplete_exons)

--- a/tests/test_calculate.py
+++ b/tests/test_calculate.py
@@ -14,7 +14,7 @@ def test_mean(populated_db):
         results = query.all()
         assert len(results) == 2
         sample_ids = set(result[0] for result in results)
-        assert sample_ids == set(['sample', 'sample2'])  # sample id
+        assert sample_ids == set(["sample", "sample2"])  # sample id
         result = results[0]
         for metric in filter(None, result[1:]):
             assert isinstance(metric, float)
@@ -26,7 +26,7 @@ def test_mean_with_samples(populated_db):
         # GIVEN a database loaded with 2 samples
         assert len(session.all(Sample.select())) == 2
         # WHEN calculating mean values across metrics for a particular sample
-        sample_id = 'sample'
+        sample_id = "sample"
         query = populated_db.mean(sample_ids=[sample_id])
         # THEN the results should be limited to that sample
         results = query.all()
@@ -47,7 +47,7 @@ def test_gene(populated_db):
         results = query.all()
         assert len(results) == 2
         result = results[0]
-        assert result[0] == 'sample'
+        assert result[0] == "sample"
         assert result[-1] == gene_id
 
 
@@ -56,7 +56,7 @@ def test_sample_coverage(populated_db):
     with populated_db.begin() as session:
         # GIVEN a database loaded with 2 samples
         assert len(session.all(Sample.select())) == 2
-        sample_ids = ('sample', 'sample2')
+        sample_ids = ("sample", "sample2")
         gene_ids = (14825, 28706)
         # WHEN calculating coverage for sample 'sample' on gene 14825
         query = populated_db.sample_coverage(sample_ids=sample_ids, genes=gene_ids)
@@ -64,4 +64,4 @@ def test_sample_coverage(populated_db):
         # is a dict with keys mean_coverage and mean completeness
         assert set(query.keys()) == set(sample_ids)
         for _, value in query.items():
-            assert set(value.keys()) == set(['mean_coverage', 'mean_completeness'])
+            assert set(value.keys()) == set(["mean_coverage", "mean_completeness"])

--- a/tests/test_sambamba.py
+++ b/tests/test_sambamba.py
@@ -7,14 +7,12 @@ THRESHOLDS = (10, 20)
 
 
 def test_run_sambamba(tmpdir, bed_path, bam_path):
-    out_path = tmpdir.join('ccds.coverage.bed')
-    run_sambamba(bam_path, bed_path, outfile=str(out_path),
-                 cov_thresholds=THRESHOLDS)
+    out_path = tmpdir.join("ccds.coverage.bed")
+    run_sambamba(bam_path, bed_path, outfile=str(out_path), cov_thresholds=THRESHOLDS)
     assert out_path.exists()
 
 
 def test_run_sambamba_missing(tmpdir, reset_path, bed_path, bam_path):
-    out_path = tmpdir.join('ccds.coverage.bed')
+    out_path = tmpdir.join("ccds.coverage.bed")
     with pytest.raises(OSError):
-        run_sambamba(bam_path, bed_path, outfile=str(out_path),
-                     cov_thresholds=THRESHOLDS)
+        run_sambamba(bam_path, bed_path, outfile=str(out_path), cov_thresholds=THRESHOLDS)

--- a/tests/test_sex.py
+++ b/tests/test_sex.py
@@ -1,27 +1,27 @@
 # -*- coding: utf-8 -*-
-from chanjo.sex import SexGuess, sex_from_bam, predict_sex
+from chanjo.sex import SexGuess, predict_sex, sex_from_bam
 
 
 def test_SexGuess():
     # create a sex guess tuple
-    sex = SexGuess(10.2, 8.1, 'male')
+    sex = SexGuess(10.2, 8.1, "male")
 
     assert sex.x_coverage == 10.2
     assert sex.y_coverage == 8.1
-    assert sex.sex == 'male'
+    assert sex.sex == "male"
 
 
 def test_predict_sex():
-    assert predict_sex(x_coverage=10.2, y_coverage=8.1) == 'male'
-    assert predict_sex(x_coverage=20.9, y_coverage=.01) == 'female'
+    assert predict_sex(x_coverage=10.2, y_coverage=8.1) == "male"
+    assert predict_sex(x_coverage=20.9, y_coverage=0.01) == "female"
     # shouldn't raise ``ZeroDivisionError``
-    assert predict_sex(x_coverage=5.12, y_coverage=0) == 'female'
+    assert predict_sex(x_coverage=5.12, y_coverage=0) == "female"
     # what does this even mean?
-    assert predict_sex(x_coverage=0, y_coverage=10) == 'unknown'
+    assert predict_sex(x_coverage=0, y_coverage=10) == "unknown"
 
 
 def test_sex_from_bam(bam_path):
     # use fixtures bam - doesn't have coverage on Y chromosome
     result = sex_from_bam(bam_path)
     assert result.x_coverage > result.y_coverage
-    assert result.sex == 'female'
+    assert result.sex == "female"


### PR DESCRIPTION
## Description

### Fixed
- Fix #265 - Update actions for python 3.11


### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_[TOOL]-t [TOOL] -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [x] Tests executed by GitHub Actions
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
