### PR TITLE
Fix action version, bump to 4.7.2 manually

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "4.7.1"
+current_version = "4.7.2"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 search = "{current_version}"

--- a/.github/workflows/pypi_build_n_publish.yml
+++ b/.github/workflows/pypi_build_n_publish.yml
@@ -34,7 +34,7 @@ jobs:
         bdist_wheel
 
    - name: Publish distribution 📦 to PyPI
-     uses: pypa/gh-action-pypi-publish@master
+     uses: pypa/gh-action-pypi-publish@release/v1
      with:
        user: __token__
        password: ${{ secrets.PYPI_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [4.7.2] - 2024-12-10
 - Refactored to allow later python versions than 3.8 (pkg_resources to importlib, os.path and path.py to pathlib, distutils to shutil) [#262](https://github.com/Clinical-Genomics/chanjo/pull/262)
 - Updated actions to use python 3.11, add changelog reminder, add linting, format for linters [#266](https://github.com/Clinical-Genomics/chanjo/pull/266)
-
+- Update PyPi publish action to v1
 
 ## [4.7.1] - 2024-06-05
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Refactored to allow later python versions than 3.8 (pkg_resources to importlib, os.path and path.py to pathlib, distutils to shutil) [#262](https://github.com/Clinical-Genomics/chanjo/pull/262)
 - Updated actions to use python 3.11, add changelog reminder, add linting, format for linters [#266](https://github.com/Clinical-Genomics/chanjo/pull/266)
 
+
 ## [4.7.1] - 2024-06-05
 ### Fixed
 - Added `cryptography` module among the dependencies

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,13 +1,13 @@
-# So long as you are building a pure Python package that supports
-# Python 2 and 3.
-[wheel]
-universal=1
+[bumpversion]
+current_version = 4.7.2
 
-# make pypi render markdown files
+[wheel]
+universal = 1
+
 [metadata]
 description-file = README.md
 
 [tool:pytest]
-looponfailroots =
-    tests/
-    chanjo/
+looponfailroots = 
+	tests/
+	chanjo/

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
     # Versions should comply with PEP440. For a discussion on
     # single-sourcing the version across setup.py and the project code,
     # see http://packaging.python.org/en/latest/tutorial.html#version
-    version="4.7.1",
+    version="4.7.2",
     description="Coverage analysis tool for clinical sequencing",
     # What does your project relate to? Separate with spaces.
     keywords="coverage sequencing clinical exome completeness diagnostics",


### PR DESCRIPTION
## Description


## [4.7.2] - 2024-12-10
- Refactored to allow later python versions than 3.8 (pkg_resources to importlib, os.path and path.py to pathlib, distutils to shutil) [#262](https://github.com/Clinical-Genomics/chanjo/pull/262)
- Updated actions to use python 3.11, add changelog reminder, add linting, format for linters [#266](https://github.com/Clinical-Genomics/chanjo/pull/266)
- Update PyPi publish action to v1

### How to prepare for test

- [ ] Ssh to relevant server (depending on type of change)
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for Hasta):
    ```shell
    bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_[TOOL]-t [TOOL] -b [THIS-BRANCH-NAME] -a
    ```

### How to test

- [ ] Do ...

### Expected test outcome

- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review

- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan

- [ ] Document in ...
- [ ] Deploy this branch on ...
- [ ] Inform to ...
